### PR TITLE
add remove-user command

### DIFF
--- a/juju_spell/cli/ping.py
+++ b/juju_spell/cli/ping.py
@@ -29,7 +29,7 @@ class PingCMD(JujuReadCMD):
     overview = textwrap.dedent(
         """
         The ping command check connection to controller(s).
-    
+
         Example:
         $ juju-spell ping
         [

--- a/juju_spell/cli/ping.py
+++ b/juju_spell/cli/ping.py
@@ -28,22 +28,22 @@ class PingCMD(JujuReadCMD):
     help_msg = "Check connection to controller(s)"
     overview = textwrap.dedent(
         """
-    The ping command check connection to controller(s).
-
-    Example:
-    $ juju-spell ping
-    [
-     {
-      "context": {
-       "uuid": "e9fe93a8-b705-4067-8f30-6eec183eeb4f",
-       "name": "controller1",
-       "customer": "Gandalf"
-      },
-      "success": true,
-      "output": "accessible",
-      "error": null
-     }
-    ]
-    """
+        The ping command check connection to controller(s).
+    
+        Example:
+        $ juju-spell ping
+        [
+         {
+          "context": {
+           "uuid": "e9fe93a8-b705-4067-8f30-6eec183eeb4f",
+           "name": "controller1",
+           "customer": "Gandalf"
+          },
+          "success": true,
+          "output": "accessible",
+          "error": null
+         }
+        ]
+        """
     )
     command = PingCommand

--- a/juju_spell/cli/remove_user.py
+++ b/juju_spell/cli/remove_user.py
@@ -32,25 +32,36 @@ class RemoveUserCMD(JujuWriteCMD):
         The command will remove user on controller.
 
         Example:
-        $ juju_spell remove-user --user newuser
-
+        $ juju-spell remove-user --user newuser
+        Continue on cmd: remove-user parsed_args: Namespace(silent=False,
+        run_type='serial', filter='', models=None, user='newuser')[Y/n]: y
         [
-          [
-            {
-              "context": {
-                "name": "controller1",
-                "customer": "customer1"
-              },
-              "output": null
-            },
-            {
-              "context": {
-                "name": "controller2",
-                "customer": "customer2"
-              },
-              "output": null
-            }
-          ]
+         {
+          "context": {
+           "uuid": "e9fe93a8-b705-4067-8f30-6eec183eeb4f",
+           "name": "controller1",
+           "customer": "Gandalf"
+          },
+          "success": true,
+          "output": true,
+          "error": null
+         },
+         {
+          "context": {
+           "uuid": "93638105-296a-4bde-8bee-17a6dc04b955",
+           "name": "controller2",
+           "customer": "Gandalf"
+          },
+          "success": false,
+          "output": null,
+          "error": {
+           "message": "['failed to delete user \"newuser\": user \"newuser\" not
+                       found']",
+           "errors": [
+            "failed to delete user \"newuser\": user \"newuser\" not found"
+           ]
+          }
+         }
         ]
         """
     )

--- a/juju_spell/cli/remove_user.py
+++ b/juju_spell/cli/remove_user.py
@@ -1,0 +1,67 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""JujuSpell juju remove user command."""
+import textwrap
+
+from craft_cli.dispatcher import _CustomArgumentParser
+
+from juju_spell.cli.base import JujuWriteCMD
+from juju_spell.commands.remove_user import RemoveUserCommand
+
+
+class RemoveUserCMD(JujuWriteCMD):
+    """JujuSpell remove user command."""
+
+    name = "remove-user"
+    help_msg = "remove juju user to remote controller"
+    overview = textwrap.dedent(
+        """
+        The command will remove user on controller.
+
+        Example:
+        $ juju_spell remove-user --user newuser
+
+        [
+          [
+            {
+              "context": {
+                "name": "controller1",
+                "customer": "customer1"
+              },
+              "output": null
+            },
+            {
+              "context": {
+                "name": "controller2",
+                "customer": "customer2"
+              },
+              "output": null
+            }
+          ]
+        ]
+        """
+    )
+
+    command = RemoveUserCommand
+
+    def fill_parser(self, parser: _CustomArgumentParser) -> None:
+        super().fill_parser(parser=parser)
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="username to remove",
+            required=True,
+        )

--- a/juju_spell/cmd.py
+++ b/juju_spell/cmd.py
@@ -24,7 +24,7 @@ COMMAND_GROUPS = [
     CommandGroup(
         "ReadOnly", [cli.StatusCMD, cli.ShowControllerInformationCMD, cli.PingCMD]
     ),
-    CommandGroup("ReadWrite", [cli.AddUserCMD, cli.GrantCMD]),
+    CommandGroup("ReadWrite", [cli.AddUserCMD, cli.GrantCMD, cli.RemoveUserCMD]),
 ]
 
 GLOBAL_ARGS = [

--- a/juju_spell/commands/base.py
+++ b/juju_spell/commands/base.py
@@ -76,7 +76,7 @@ class BaseJujuCommand(metaclass=ABCMeta):
 
     @abstractmethod
     async def execute(
-        self, controller: Controller, **kwargs
+        self, controller: Controller, *args, **kwargs
     ) -> Any:  # pragma: no cover
         """Execute function.
 

--- a/juju_spell/commands/base.py
+++ b/juju_spell/commands/base.py
@@ -64,7 +64,10 @@ class BaseJujuCommand(metaclass=ABCMeta):
         self.logger.info("%s running %s command", controller.controller_uuid, self.name)
         try:
             output = await self.execute(controller, **kwargs)
-            return Result(True, output=output)
+            if not isinstance(output, Result):
+                output = Result(True, output=output)
+
+            return output
         except Exception as error:
             self.logger.exception(error)
             return Result(False, output=None, error=error)

--- a/juju_spell/commands/remove_user.py
+++ b/juju_spell/commands/remove_user.py
@@ -17,7 +17,6 @@
 from typing import Optional
 
 from juju.controller import Controller
-from juju.errors import JujuError
 
 from juju_spell.commands.base import BaseJujuCommand
 
@@ -27,10 +26,7 @@ __all__ = ["RemoveUserCommand"]
 class RemoveUserCommand(BaseJujuCommand):
     async def execute(
         self, controller: Controller, *, user: Optional[str] = None, **kwargs
-    ) -> str:
-        try:
-            await controller.remove_user(username=user)
-            return f"user `{user}` was successfully removed"
-        except JujuError as error:
-            self.logger.exception(error)
-            return f"failed to delete user `{user}` with error: {error}"
+    ) -> bool:
+        await controller.remove_user(username=user)
+        self.logger.info(f"user `{user}` was successfully removed")
+        return True

--- a/juju_spell/commands/remove_user.py
+++ b/juju_spell/commands/remove_user.py
@@ -1,0 +1,36 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""JujuSpell juju remove user command."""
+from typing import Optional
+
+from juju.controller import Controller
+from juju.errors import JujuError
+
+from juju_spell.commands.base import BaseJujuCommand
+
+__all__ = ["RemoveUserCommand"]
+
+
+class RemoveUserCommand(BaseJujuCommand):
+    async def execute(
+        self, controller: Controller, *, user: Optional[str] = None, **kwargs
+    ) -> str:
+        try:
+            await controller.remove_user(username=user)
+            return f"user `{user}` was successfully removed"
+        except JujuError as error:
+            self.logger.exception(error)
+            return f"failed to delete user `{user}` with error: {error}"

--- a/tests/unit/cli/test_cli_remove_user.py
+++ b/tests/unit/cli/test_cli_remove_user.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -13,20 +13,22 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import argparse
+from unittest import mock
 
-"""JujuSpell cli commands."""
-from .add_user import AddUserCMD
-from .grant import GrantCMD
-from .ping import PingCMD
-from .remove_user import RemoveUserCMD
-from .show_controller import ShowControllerInformationCMD
-from .status import StatusCMD
+from juju_spell.cli import RemoveUserCMD
 
-__all__ = [
-    "AddUserCMD",
-    "GrantCMD",
-    "RemoveUserCMD",
-    "PingCMD",
-    "StatusCMD",
-    "ShowControllerInformationCMD",
-]
+
+def test_fill_parser():
+    """Test add additional CLI arguments with BaseJujuCMD."""
+    parser = mock.MagicMock(spec=argparse.ArgumentParser)
+
+    cmd = RemoveUserCMD(None)
+    cmd.fill_parser(parser)
+
+    assert parser.add_argument.call_count == 5
+    parser.add_argument.assert_has_calls(
+        [
+            mock.call("--user", type=str, help="username to remove", required=True),
+        ]
+    )

--- a/tests/unit/commands/test_remove_user.py
+++ b/tests/unit/commands/test_remove_user.py
@@ -1,0 +1,47 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from unittest import mock
+
+import pytest
+from juju import juju
+from juju.errors import JujuError
+
+from juju_spell.commands.remove_user import RemoveUserCommand
+
+
+@pytest.mark.asyncio
+async def test_ping_execute():
+    """Test execute function for RemoveUserCommand."""
+    user = "test-user"
+    controller = mock.MagicMock(spec=juju.Controller)
+
+    remove_user = RemoveUserCommand()
+    result = await remove_user.execute(controller, user=user)
+
+    controller.remove_user.assert_called_once_with(username=user)
+    assert result == f"user `{user}` was successfully removed"
+
+
+@pytest.mark.asyncio
+async def test_ping_execute_exception():
+    """Test execute function for RemoveUserCommand with exception raised."""
+    user = "test-user"
+    controller = mock.MagicMock(spec=juju.Controller)
+    controller.remove_user.side_effect = JujuError
+
+    remove_user = RemoveUserCommand()
+    result = await remove_user.execute(controller, user=user)
+    assert result == f"failed to delete user `{user}` with error: "

--- a/tests/unit/commands/test_remove_user.py
+++ b/tests/unit/commands/test_remove_user.py
@@ -17,7 +17,6 @@ from unittest import mock
 
 import pytest
 from juju import juju
-from juju.errors import JujuError
 
 from juju_spell.commands.remove_user import RemoveUserCommand
 
@@ -32,16 +31,4 @@ async def test_ping_execute():
     result = await remove_user.execute(controller, user=user)
 
     controller.remove_user.assert_called_once_with(username=user)
-    assert result == f"user `{user}` was successfully removed"
-
-
-@pytest.mark.asyncio
-async def test_ping_execute_exception():
-    """Test execute function for RemoveUserCommand with exception raised."""
-    user = "test-user"
-    controller = mock.MagicMock(spec=juju.Controller)
-    controller.remove_user.side_effect = JujuError
-
-    remove_user = RemoveUserCommand()
-    result = await remove_user.execute(controller, user=user)
-    assert result == f"failed to delete user `{user}` with error: "
+    assert result is True


### PR DESCRIPTION
example:
```bash
$ juju-spell add-user --user rgildein87                       
Continue on cmd: add-user parsed_args: Namespace(silent=False, run_type='serial', filter='', models=None, user='rgildein87', display_name=None, password=None)[Y/n]: y
Password(If empty will use random password): 
Please put user information to personal config(/home/rgildein/.local/share/juju-spell/config.personal.yaml):

controllers:
- uuid: e9fe93a8-b705-4067-8f30-6eec183eeb4f
  name: u1
  user: rgildein87
  password: JvalNAbQ5GlyemdoJXp5VshsrvSxfPt-RCFHMxZa
- uuid: 93638105-296a-4bde-8bee-17a6dc04b955
  name: rgildein2-serverstack
  user: rgildein87
  password: 2ROsvWcIj5NXBh9muOzmkFWdGPUu-3vjOJLp3syW
$ juju-spell remove-user --user rgildein87
Continue on cmd: remove-user parsed_args: Namespace(silent=False, run_type='serial', filter='', models=None, user='rgildein87')[Y/n]: 
[
 {
  "context": {
   "uuid": "e9fe93a8-b705-4067-8f30-6eec183eeb4f",
   "name": "u1",
   "customer": "rgildein"
  },
  "success": true,
  "output": true,
  "error": null
 },
 {
  "context": {
   "uuid": "93638105-296a-4bde-8bee-17a6dc04b955",
   "name": "rgildein2-serverstack",
   "customer": "rgildein"
  },
  "success": true,
  "output": true,
  "error": null
 }
]
```