### PR TITLE
prepare LXD environemnt (client + 2 controllers)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ dev-environment:
 
 functional: build
 	@echo "Executing functional tests using built snap"
-	# @TEST_SNAP=${SNAP_FILE} tox -e func -- ${FUNC_ARGS}
+	@TEST_SNAP=${SNAP_FILE} tox -e func -- ${FUNC_ARGS}
 
 pre-commit:
 	@tox -e pre-commit

--- a/juju_spell/config.py
+++ b/juju_spell/config.py
@@ -256,3 +256,21 @@ def load_config(
 
     config = _validate_config(source)
     return config
+
+
+def convert_config(original_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert Juju config from `juju show-controller` to JujuSpell config.
+
+    Returns first object of dictionary, because format of output is defined as
+    a dictionary where key is name of controller.
+    """
+    for name, controller in original_config.items():
+        config = {
+            "uuid": controller["details"]["uuid"],
+            "name": name,
+            "endpoint": controller["details"]["api-endpoints"][0],
+            "ca_cert": controller["details"]["ca-cert"],
+            "user": controller["account"]["user"],
+            "password": controller["account"]["password"],
+        }
+        return config

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,10 @@ unittests =
     pytest-mock
 
 functests =
-
+    # NOTE (rgildein): https://discuss.linuxcontainers.org/t/5-0-2-raises-connection-reset-by-peer-exception-on-pylxds-container-execute/16292
+    pylxd @ git+https://github.com/lxc/pylxd
+    pytest
+    pytest-asyncio
 
 verify =
     twine

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,120 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""JujuSpell configuration for functional tests."""
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Callable, Generator
+
+import pylxd.models
+import pytest
+from pylxd import Client
+
+from tests.functional.setup_lxd import cleanup_environment, setup_environment
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_SERIES = "jammy"
+CLIENT_CONAINER = pytest.StashKey[str]()
+CONTROLLERS_CONTAINERS = pytest.StashKey[list]()
+
+
+def check_dependencies(*dependencies) -> None:
+    """Check if dependencies are installed."""
+    errors = []
+    for dependence in dependencies:
+        try:
+            subprocess.check_output(["which", dependence])
+        except subprocess.CalledProcessError:
+            errors.append(f"Missing {dependence} dependency.")
+
+    if errors:
+        raise RuntimeError(os.linesep.join(errors))
+
+
+def build_snap(build: bool) -> Path:
+    """Build JujuSpell snap."""
+    path = Path("juju-spell.snap")
+    if build:
+        print("snapcraft: building JujuSpell")
+        subprocess.check_output(["snapcraft", "pack"])
+        subprocess.check_output(["bash", "rename.sh"])
+
+    if path.exists():
+        return path
+
+    raise RuntimeError("Something went wrong with building snap")
+
+
+def pytest_addoption(parser):
+    """Add custom CLI options."""
+    parser.addoption(
+        "--series",
+        type=str,
+        default=DEFAULT_SERIES,
+        help="create lxd controllers with series",
+    )
+    parser.addoption(
+        "--no-build", action="store_false", help="flag to disable building new snap"
+    )
+
+
+def pytest_configure(config):
+    """Configure environment."""
+    series = config.getoption("series")
+    build = config.getoption("no_build")
+
+    check_dependencies("juju", "lxd", "snapcraft")
+    snap_path = build_snap(build)
+    try:
+        client, controllers = setup_environment(series, snap_path)
+        config.stash[CLIENT_CONAINER] = client
+        config.stash[CONTROLLERS_CONTAINERS] = controllers
+        config.add_cleanup(cleanup_environment)
+    except Exception:
+        cleanup_environment()
+        raise
+
+
+@pytest.fixture
+def client(pytestconfig, tmp_path, controllers) -> pylxd.models.Instance:
+    """Return LXD container where JujuSpell is installed."""
+    name = pytestconfig.stash[CLIENT_CONAINER]
+    client = Client()
+    return client.instances.get(name)
+
+
+@pytest.fixture
+def controllers(pytestconfig) -> Generator[pylxd.models.Instance, None, None]:
+    """Return LXD containers for controllers."""
+    controllers = pytestconfig.stash[CONTROLLERS_CONTAINERS]
+    client = Client()
+
+    return (client.instances.get(name) for name in controllers)
+
+
+@pytest.fixture
+def juju_spell_run(client) -> Callable:
+    """Return Callable function to execute JujuSpell command."""
+
+    def wrapper(*args):
+        return client.execute(
+            ["juju-spell", *args], user=1000, group=1000, cwd="/home/ubuntu"
+        )
+
+    return wrapper

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -51,8 +51,9 @@ def check_dependencies(*dependencies) -> None:
 
 def build_snap(build: bool) -> Path:
     """Build JujuSpell snap."""
-    path = Path("juju-spell.snap")
-    if build:
+    path = Path(os.environ.get("TEST_SNAP", "./juju-spell.snap"))
+
+    if build and "TEST_SNAP" not in os.environ:
         print("snapcraft: building JujuSpell")
         subprocess.check_output(["snapcraft", "pack"])
         subprocess.check_output(["bash", "rename.sh"])

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -39,11 +39,11 @@ SESSION_UUID_KEY = pytest.StashKey[str]()
 def check_dependencies(*dependencies) -> None:
     """Check if dependencies are installed."""
     errors = []
-    for dependence in dependencies:
+    for dependency in dependencies:
         try:
-            subprocess.check_output(["which", dependence])
+            subprocess.check_output(["which", dependency])
         except subprocess.CalledProcessError:
-            errors.append(f"Missing {dependence} dependency.")
+            errors.append(f"Missing {dependency} dependency.")
 
     if errors:
         raise RuntimeError(os.linesep.join(errors))
@@ -130,8 +130,13 @@ def juju_spell_run(client) -> Callable:
     """Return Callable function to execute JujuSpell command."""
 
     def wrapper(*args):
-        return client.execute(
+        result = client.execute(
             ["juju-spell", *args], user=1000, group=1000, cwd="/home/ubuntu"
         )
+        print(
+            f"LXD: command {args} finished with exit_code {result.exit_code}"
+            f"{os.linesep}stdout: {result.stdout}{os.linesep}stderr: {result.stderr}"
+        )
+        return result
 
     return wrapper

--- a/tests/functional/setup_lxd.py
+++ b/tests/functional/setup_lxd.py
@@ -1,0 +1,214 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""JujuSpell configuration for functional tests."""
+import json
+import random
+import subprocess
+import textwrap
+from pathlib import Path
+from string import ascii_lowercase
+from time import sleep
+from typing import Any, Dict, List, Tuple, Union
+
+import yaml
+from pylxd import Client
+from pylxd.models import Container, Instance
+
+from juju_spell.config import convert_config
+
+CONTAINER_PREFIX = "JujuSpell"
+DEFAULT_DIRECTORY = Path("/home/ubuntu/.local/share/juju-spell")
+SSH_CONFIG = textwrap.dedent(
+    """
+Host *
+  StrictHostKeyChecking=accept-new
+"""
+)
+CONTROLLER_API_PORT = 17007
+NUMBER_OF_CONTROLLERS = 2
+
+
+def get_uuid(length: int) -> str:
+    """Get random uuid."""
+    return "".join(random.choice(ascii_lowercase) for _ in range(length))
+
+
+def get_controller(name: str) -> Dict[str, Any]:
+    """Get information about controller."""
+    output = subprocess.check_output(
+        ["juju", "show-controller", "--show-password", "--format", "json", name]
+    ).decode()
+    return json.loads(output)
+
+
+def try_unregister_controller(name: str) -> None:
+    """Try to unregister controller without raising error."""
+    try:
+        subprocess.check_call(
+            ["juju", "unregister", "-y", name],
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        print(f"Juju: controller {name} was unregistered")
+
+
+def create_container(name: str, series: str) -> Container:
+    """Create instance."""
+    client = Client()
+    container_name = f"{CONTAINER_PREFIX}-{name}-{get_uuid(5)}"
+    config = {
+        "name": container_name,
+        "source": {
+            "type": "image",
+            "mode": "pull",
+            "server": "https://cloud-images.ubuntu.com/daily",
+            "protocol": "simplestreams",
+            "alias": series,
+        },
+        "type": "container",
+    }
+
+    print(f"LXD: creating {name} with name: `{container_name}` and series {series}")
+    container: Container = client.containers.create(config, wait=True)
+    container.start(wait=True)
+    print(f"LXD: {container.name} is running")
+    return container
+
+
+def create_client_instance(series: str, snap_path: Union[str, Path]) -> Instance:
+    """Create client instance."""
+    client = create_container("client", series)
+    sleep(5)  # TODO: we need to wait for container to be fully readyx
+    client.execute(["sudo", "ufw", "enable"], user=1000)
+    # drop direct connection to any controller, e.g. <ip>:CONTROLLER_API_PORT
+    client.execute(["sudo", "ufw", "deny", "out", str(CONTROLLER_API_PORT)], user=1000)
+    client.execute(
+        ["ssh-keygen", "-q", "-f", "/home/ubuntu/.ssh/id_rsa", "-N", ""], user=1000
+    )
+    with open(snap_path, "rb") as snap:
+        client.files.put(
+            "/home/ubuntu/juju-spell.snap", snap.read(), uid=1000, gid=1000
+        )
+
+    client.execute(
+        ["sudo", "snap", "install", "./juju-spell.snap", "--devmode"],
+        user=1000,
+        cwd="/home/ubuntu",
+    )
+
+    # NOTE (rgildein): Right now JujuSpell is not creating `.local/share/juju-spell`
+    # directory, so we need to create it
+    client.execute(["mkdir", "-p", str(DEFAULT_DIRECTORY)], user=1000)
+
+    return client
+
+
+def boostrap_controller(name: str, series: str, ssh_key: str) -> Instance:
+    """Bootstrap controller on top of instance."""
+    # NOTE (rgildein): we could not use f"--config authorized-keys='{ssh_key}'",
+    # because it's not appending key and Juju will not have access to this controller
+    subprocess.check_output(
+        [
+            "juju",
+            "bootstrap",
+            "--no-switch",
+            "--bootstrap-series",
+            f"{series}",
+            "--config",
+            f"api-port={CONTROLLER_API_PORT}",
+            "--config",
+            f"default-series={series}",
+            "localhost",
+            name,
+        ]
+    )
+    info = subprocess.check_output(
+        ["juju", "show-controller", name.lower(), "--format", "json"]
+    ).decode()
+    info = json.loads(info)
+    instance_id = info[name.lower()]["controller-machines"]["0"]["instance-id"]
+    client = Client()
+    # ranme controller container so we can easily access it a remove it later
+    controller = client.instances.get(instance_id)
+    controller.execute(
+        ["sh", "-c", f"echo '{ssh_key}'>>/home/ubuntu/.ssh/authorized_keys"],
+        user=1000,
+    )
+    controller.stop(wait=True)
+    controller.rename(name, wait=True)
+    controller.start(wait=True)
+    return controller
+
+
+def setup_environment(
+    series: str, snap_path: Union[str, Path]
+) -> Tuple[str, List[str]]:
+    """Set up LXD environment.
+
+    Creates client with JujuSpell installed and NUMBER_OF_CONTROLLERS for testing.
+    """
+    # JujuSpell client
+    client = create_client_instance(series, snap_path)  # JujuSpell client
+    client_ssh_key = client.execute(
+        ["cat", "/home/ubuntu/.ssh/id_rsa.pub"], user=1000
+    ).stdout.strip()
+    # Note(rgildein): Right now our connection could not accept ssh key
+    # automaticaly, that's why we need to do this
+    client.files.put("/home/ubuntu/.ssh/config", SSH_CONFIG, uid=1000)
+
+    # controllers
+    controllers = []
+    for _ in range(NUMBER_OF_CONTROLLERS):
+        name = f"{CONTAINER_PREFIX}-controller-{get_uuid(5)}"
+        controller = boostrap_controller(name, series, client_ssh_key)
+        controllers.append(controller.name)
+
+    # creates JujuSpell config
+    config = {"controllers": []}
+    for controller in controllers:
+        info = convert_config(get_controller(controller.lower()))
+        ip_address, _ = info["endpoint"].split(":")
+        config["controllers"].append(
+            {
+                "owner": "Frodo",
+                "customer": "Gandalf",
+                **info,
+                "connection": {"destination": ip_address},
+            }
+        )
+    config_string = yaml.safe_dump(config)
+    client.files.put(
+        DEFAULT_DIRECTORY / "config.yaml", config_string, uid=1000, gid=1000
+    )
+
+    return client.name, controllers
+
+
+def cleanup_environment():
+    """Clean up LXD environment.
+
+    Remove all instances with names starting with CONTAINER_PREFIX.
+    """
+    client = Client()
+    for instance in client.instances.all():
+        if instance.name.startswith(CONTAINER_PREFIX):
+            if instance.status_code != 102:  # check if instance is not already stopped
+                instance.stop(wait=True)
+
+            instance.delete()
+            print(f"LXD: {instance.name} was removed")
+            try_unregister_controller(instance.name.lower())

--- a/tests/functional/test_connection.py
+++ b/tests/functional/test_connection.py
@@ -1,13 +1,16 @@
 import json
 
+OK_EXIT_CODE = 0
+ARGPARSING_ERROR_EXIT_CODE = 127
+
 
 def test_help(juju_spell_run):
     """Test printing --help."""
     help_flag = juju_spell_run("--help")
-    assert help_flag.exit_code == 0
+    assert help_flag.exit_code == OK_EXIT_CODE
 
     help_default = juju_spell_run()
-    assert help_default.exit_code == 127
+    assert help_default.exit_code == ARGPARSING_ERROR_EXIT_CODE
 
     assert help_flag.stdout == help_default.stdout
 
@@ -16,7 +19,7 @@ def test_connection_ping(juju_spell_run):
     """Test connection with ping command to each controller."""
     result = juju_spell_run("ping")
 
-    assert result.exit_code == 0
+    assert result.exit_code == OK_EXIT_CODE
     result_json = json.loads(result.stdout)
     for controller in result_json:
         assert controller["success"] is True

--- a/tests/functional/test_connection.py
+++ b/tests/functional/test_connection.py
@@ -1,0 +1,23 @@
+import json
+
+
+def test_help(juju_spell_run):
+    """Test printing --help."""
+    help_flag = juju_spell_run("--help")
+    assert help_flag.exit_code == 0
+
+    help_default = juju_spell_run()
+    assert help_default.exit_code == 127
+
+    assert help_flag.stdout == help_default.stdout
+
+
+def test_connection_ping(juju_spell_run):
+    """Test connection with ping command to each controller."""
+    result = juju_spell_run("ping")
+
+    assert result.exit_code == 0
+    result_json = json.loads(result.stdout)
+    for controller in result_json:
+        assert controller["success"] is True
+        assert controller["output"] == "accessible"


### PR DESCRIPTION
- creates "client" LXD container with JujuSpell installed
- bootstrap N controllers

TODO:
- [x] figure out why `setup_environment` works when each step is run individually, but not at once
- [x] figure out why `execute` raises [this](https://pastebin.ubuntu.com/p/2QcTSWCBSd/) errors (command is executed, but this error is always there)
- [x] creates config file for JujuSpell and copy paste it to the client
- [x] add simple test with ping comand