### PR TITLE
feat(juju_spell/cli/base.py): Add dry-run argument

### DIFF
--- a/tests/unit/cli/test_cli_base.py
+++ b/tests/unit/cli/test_cli_base.py
@@ -35,7 +35,7 @@ def test_base_cmd_fill_parser(base_cmd):
 
 def test_base_cmd_run(base_cmd):
     """Test run from BaseCMD."""
-    parsed_args = argparse.Namespace(**{"test": True})
+    parsed_args = argparse.Namespace(**{"dry_run": False, "test": True})
     base_cmd.before = mock_before = MagicMock()
     base_cmd.execute = mock_execute = MagicMock()
     base_cmd.format_output = mock_format_output = MagicMock()
@@ -186,3 +186,27 @@ def test_juju_write_cmd_run(
         juju_write_cmd.run(parsed_args)
 
     assert (mock_run.call_count != 0) == executed
+
+
+@pytest.mark.parametrize(
+    "parsed_args, executed",
+    [
+        ({"dry_run": False}, True),
+        ({"dry_run": True, "filter": None}, False),
+    ],
+)
+@patch("juju_spell.cli.base.BaseJujuCMD.execute")
+@patch("juju_spell.cli.base.get_filtered_config")
+def test_juju_cmd_dry_run(
+    mock_execute,
+    mock_get_filtered_config,
+    parsed_args,
+    executed,
+    base_juju_cmd,
+    test_config,
+):
+    parsed_args = argparse.Namespace(**parsed_args)
+    base_juju_cmd.safe_parsed_args_output = MagicMock()
+    mock_get_filtered_config.return_value = test_config
+    base_juju_cmd.run(parsed_args)
+    assert (base_juju_cmd.execute.call_count != 0) == executed

--- a/tests/unit/cli/test_cli_remove_user.py
+++ b/tests/unit/cli/test_cli_remove_user.py
@@ -26,7 +26,7 @@ def test_fill_parser():
     cmd = RemoveUserCMD(None)
     cmd.fill_parser(parser)
 
-    assert parser.add_argument.call_count == 5
+    assert parser.add_argument.call_count == 6
     parser.add_argument.assert_has_calls(
         [
             mock.call("--user", type=str, help="username to remove", required=True),

--- a/tests/unit/cli/test_cli_remove_user.py
+++ b/tests/unit/cli/test_cli_remove_user.py
@@ -26,6 +26,7 @@ def test_fill_parser():
     cmd = RemoveUserCMD(None)
     cmd.fill_parser(parser)
 
+    # This one is to check the basic arguments is been added.
     assert parser.add_argument.call_count == 6
     parser.add_argument.assert_has_calls(
         [


### PR DESCRIPTION
output example:

```sh
$ python -m juju_spell status --dry-run
Get status for selected models in controller. 
Targets:
UUID: 74ef132a-6c96-48db-808c-76e8396f4feb
Name: local-lxd
Endpoint:10.127.138.134:17070
---
UUID: 74ef132a-6c96-48db-808c-76e8396f4fea
Name: local-lxd2
Endpoint:10.127.138.134:17070        
```