### PR TITLE
Add pre-check for BaseJujuCommand

### DIFF
--- a/juju_spell/assignment/runner.py
+++ b/juju_spell/assignment/runner.py
@@ -62,7 +62,12 @@ async def run_serial(
         logger.debug("%s running in serial", controller.controller_uuid)
         command_kwargs = vars(parsed_args)
         command_kwargs["controller_config"] = controller_config
-        output = await command.run(controller=controller, **command_kwargs)
+        pre_check = await command.pre_check(controller=controller, **command_kwargs)
+        if pre_check is not None:
+            output = pre_check
+        else:
+            output = await command.run(controller=controller, **command_kwargs)
+
         result = get_result(controller_config, output)
         results.append(result)
 

--- a/juju_spell/commands/base.py
+++ b/juju_spell/commands/base.py
@@ -56,6 +56,18 @@ class BaseJujuCommand(metaclass=ABCMeta):
                 yield model_name, model
                 await model.disconnect()
 
+    async def pre_check(self, controller: Controller, **kwargs) -> Optional[Result]:
+        """Run pre-check for command."""
+        self.logger.debug("%s running pre-check", controller.controller_uuid)
+        if not controller.is_connected():
+            self.logger.info(
+                "%s pre-check: controller is connected",
+                controller.controller_uuid,
+            )
+            return Result(
+                False, error=f"controller {controller.controller_uuid} is not connected"
+            )
+
     async def run(self, controller: Controller, **kwargs) -> Result:
         """Execute Juju command.
 

--- a/tests/unit/assignment/test_runner.py
+++ b/tests/unit/assignment/test_runner.py
@@ -14,12 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for assignment.runner."""
+import argparse
 from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
 
-from juju_spell.assignment.runner import get_result
+from juju_spell.assignment.runner import get_result, run_serial
 from juju_spell.commands.base import Result
 
 
@@ -67,3 +68,61 @@ def test_get_result(controller_config, output, exp_result):
     """Test for get_result."""
     result = get_result(controller_config, output)
     assert result == exp_result
+
+
+@pytest.mark.asyncio
+@mock.patch("juju_spell.assignment.runner.get_controller", new_callable=mock.AsyncMock)
+@mock.patch("juju_spell.assignment.runner.get_result")
+@pytest.mark.parametrize(
+    "steps",
+    [
+        [],  # no controller
+        [(MagicMock(), None, "OK", "OK")],
+        [
+            (MagicMock(), None, "run_output-1", "run_output-1"),
+            (MagicMock(), "pre_check-1", None, "pre_check-1"),
+            (MagicMock(), None, "run_output-2", "run_output-2"),
+            (MagicMock(), "pre_check-2", None, "pre_check-2"),
+            (MagicMock(), None, "run_output-3", "run_output-3"),
+            (MagicMock(), "pre_check-3", None, "pre_check-3"),
+        ],
+    ],
+)
+async def test_run_serial(mock_get_result, mock_get_controller, steps):
+    """Test run in serial."""
+    config = mock.MagicMock()
+    config.controllers = [controller_config for controller_config, _, _, _ in steps]
+    command = mock.AsyncMock()
+    command.pre_check.side_effect = [pre_check for _, pre_check, _, _ in steps]
+    command.run.side_effect = [run for _, _, run, _ in steps if run]
+    exp_result = [output for _, _, _, output in steps]
+    # get_result returns output itself
+    mock_get_result.side_effect = lambda controller_config, output: output
+
+    result = await run_serial(config, command, argparse.Namespace())
+
+    assert result == exp_result
+
+    for controller_config, _, run_output, exp_output in steps:
+        mock_get_controller.assert_has_awaits(
+            [mock.call(controller_config, config.connection.get.return_value)]
+        )
+        command.pre_check.assert_has_awaits(
+            [
+                mock.call(
+                    controller=mock_get_controller.return_value,
+                    controller_config=controller_config,
+                )
+            ]
+        )
+        if run_output is not None:
+            command.run.assert_has_awaits(
+                [
+                    mock.call(
+                        controller=mock_get_controller.return_value,
+                        controller_config=controller_config,
+                    )
+                ]
+            )
+
+        mock_get_result.assert_has_calls([mock.call(controller_config, exp_output)])

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -27,6 +27,29 @@ class TestBaseJujuCommand:
         assert test_juju_command.logger.name == test_juju_command.name
 
     @pytest.mark.asyncio
+    async def test_pre_check(self, test_juju_command):
+        """Test pre_check function."""
+        controller = mock.MagicMock()
+        controller.is_connected.return_value = True
+
+        result = await test_juju_command.pre_check(controller)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_pre_check_failed(self, test_juju_command):
+        """Test failure of pre_check function."""
+        controller = mock.MagicMock()
+        controller.controller_uuid = "1234"
+        controller.is_connected.return_value = False
+
+        result = await test_juju_command.pre_check(controller)
+
+        assert result is not None
+        assert result.success is False
+        assert result.error == "controller 1234 is not connected"
+
+    @pytest.mark.asyncio
     async def test_run(self, test_juju_command):
         """Test run function."""
         test_juju_command.execute.return_value = exp_output = {"test": "value"}


### PR DESCRIPTION
Example for custom pre-check function.
```python
async def pre_check(self, controller: Controller, **kwargs) -> Optional[Result]:
        """Run pre-check for command."""
        self.logger.debug("%s running pre-check", controller.controller_uuid)
        if not controller.is_connected():
            return Result(
                False, f"controller {controller.controller_uuid} is not connected"
            )

        # TEST
        if controller.controller_name.startswith("rgildein2"):
            return Result(False, "precheck-failed with 'haha'")
```

output
```bash
$ juju-spell ping          
[
 {
  "context": {
   "uuid": "e9fe93a8-b705-4067-8f30-6eec183eeb4f",
   "name": "u1",
   "customer": "rgildein"
  },
  "success": true,
  "output": "accessible",
  "error": null
 },
 {
  "context": {
   "uuid": "93638105-296a-4bde-8bee-17a6dc04b955",
   "name": "rgildein2-serverstack",
   "customer": "rgildein"
  },
  "success": false,
  "output": "precheck-failed with 'haha'",
  "error": null
 }
]
```