### PR TITLE
Fix/dry run

### DIFF
--- a/juju_spell/assignment/runner.py
+++ b/juju_spell/assignment/runner.py
@@ -62,9 +62,13 @@ async def run_serial(
         logger.debug("%s running in serial", controller.controller_uuid)
         command_kwargs = vars(parsed_args)
         command_kwargs["controller_config"] = controller_config
+
         pre_check = await command.pre_check(controller=controller, **command_kwargs)
+
         if pre_check is not None:
             output = pre_check
+        elif parsed_args.dry_run:
+            output = await command.dry_run(controller=controller, **command_kwargs)
         else:
             output = await command.run(controller=controller, **command_kwargs)
 

--- a/juju_spell/commands/base.py
+++ b/juju_spell/commands/base.py
@@ -68,6 +68,17 @@ class BaseJujuCommand(metaclass=ABCMeta):
                 False, error=f"controller {controller.controller_uuid} is not connected"
             )
 
+    async def dry_run(self, controller: Controller, **kwargs) -> Optional[Result]:
+        """Dry-run will output the necessary information of the target."""
+        self.logger.info("%s running dry-run", controller.controller_uuid)
+        return Result(
+            success=True,
+            output={
+                "target": controller.controller_uuid,
+                "command_doc": self.execute.__doc__,
+            },
+        )
+
     async def run(self, controller: Controller, **kwargs) -> Result:
         """Execute Juju command.
 

--- a/tests/unit/assignment/test_runner.py
+++ b/tests/unit/assignment/test_runner.py
@@ -74,53 +74,96 @@ def test_get_result(controller_config, output, exp_result):
 @mock.patch("juju_spell.assignment.runner.get_controller", new_callable=mock.AsyncMock)
 @mock.patch("juju_spell.assignment.runner.get_result")
 @pytest.mark.parametrize(
-    "steps",
+    # steps = list of
+    # [controller_config, pre_check_result, dry_run_result, run_result, exp_output]
+    "steps,parsed_args",
     [
-        [],  # no controller
-        [(MagicMock(), None, "OK", "OK")],
-        [
-            (MagicMock(), None, "run_output-1", "run_output-1"),
-            (MagicMock(), "pre_check-1", None, "pre_check-1"),
-            (MagicMock(), None, "run_output-2", "run_output-2"),
-            (MagicMock(), "pre_check-2", None, "pre_check-2"),
-            (MagicMock(), None, "run_output-3", "run_output-3"),
-            (MagicMock(), "pre_check-3", None, "pre_check-3"),
-        ],
+        ([], argparse.Namespace(dry_run=False)),  # no controller
+        (
+            [
+                (MagicMock(), None, None, "OK", "OK"),
+            ],
+            argparse.Namespace(dry_run=False),
+        ),
+        (
+            [
+                (MagicMock(), None, None, "run_output-1", "run_output-1"),
+                (MagicMock(), "pre_check-1", None, None, "pre_check-1"),
+                (MagicMock(), None, None, "run_output-2", "run_output-2"),
+                (MagicMock(), "pre_check-2", None, None, "pre_check-2"),
+                (MagicMock(), None, None, "run_output-3", "run_output-3"),
+                (MagicMock(), "pre_check-3", None, None, "pre_check-3"),
+            ],
+            argparse.Namespace(dry_run=False),
+        ),
+        (
+            [(MagicMock(), None, "dry_run-1", "run_output-4", "dry_run-1")],
+            argparse.Namespace(dry_run=True),
+        ),
+        (
+            [(MagicMock(), "pre_check-4", "dry_run-2", "run_output-5", "pre_check-4")],
+            argparse.Namespace(dry_run=True),
+        ),
+        (
+            [(MagicMock(), "pre_check-5", "dry_run-3", "run_output-6", "pre_check-5")],
+            argparse.Namespace(dry_run=False),
+        ),
+        (
+            [(MagicMock(), None, "dry_run-4", "run_output-7", "run_output-7")],
+            argparse.Namespace(dry_run=False),
+        ),
     ],
 )
-async def test_run_serial(mock_get_result, mock_get_controller, steps):
+async def test_run_serial(mock_get_result, mock_get_controller, steps, parsed_args):
     """Test run in serial."""
     config = mock.MagicMock()
-    config.controllers = [controller_config for controller_config, _, _, _ in steps]
+    config.controllers = [controller_config for controller_config, _, _, _, _ in steps]
     command = mock.AsyncMock()
-    command.pre_check.side_effect = [pre_check for _, pre_check, _, _ in steps]
-    command.run.side_effect = [run for _, _, run, _ in steps if run]
-    exp_result = [output for _, _, _, output in steps]
+    command.pre_check.side_effect = [pre_check for _, pre_check, _, _, _ in steps]
+    command.dry_run.side_effect = [dry_run for _, _, dry_run, _, _ in steps]
+    command.run.side_effect = [run for _, _, _, run, _ in steps if run]
+    exp_result = [output for _, _, _, _, output in steps]
     # get_result returns output itself
     mock_get_result.side_effect = lambda controller_config, output: output
 
-    result = await run_serial(config, command, argparse.Namespace())
+    result = await run_serial(config, command, parsed_args)
 
     assert result == exp_result
 
-    for controller_config, _, run_output, exp_output in steps:
+    for controller_config, pre_check, dry_run, run_output, exp_output in steps:
         mock_get_controller.assert_has_awaits(
             [mock.call(controller_config, config.connection.get.return_value)]
         )
+
+        command_kwargs = vars(parsed_args)
+        command_kwargs["controller_config"] = controller_config
         command.pre_check.assert_has_awaits(
             [
                 mock.call(
                     controller=mock_get_controller.return_value,
-                    controller_config=controller_config,
+                    **command_kwargs,
                 )
             ]
         )
-        if run_output is not None:
+        if not parsed_args.dry_run:
+            command.dry_run.assert_not_awaited()
+        if parsed_args.dry_run and pre_check is None:
+            command.dry_run.assert_has_awaits(
+                [
+                    mock.call(
+                        controller=mock_get_controller.return_value,
+                        **command_kwargs,
+                    )
+                ]
+            )
+            command.run.assert_not_awaited()
+
+        if pre_check is None and not parsed_args.dry_run:
             command.run.assert_has_awaits(
                 [
                     mock.call(
                         controller=mock_get_controller.return_value,
-                        controller_config=controller_config,
+                        **command_kwargs,
                     )
                 ]
             )

--- a/tests/unit/cli/test_cli_base.py
+++ b/tests/unit/cli/test_cli_base.py
@@ -35,7 +35,7 @@ def test_base_cmd_fill_parser(base_cmd):
 
 def test_base_cmd_run(base_cmd):
     """Test run from BaseCMD."""
-    parsed_args = argparse.Namespace(**{"dry_run": False, "test": True})
+    parsed_args = argparse.Namespace(**{"test": True})
     base_cmd.before = mock_before = MagicMock()
     base_cmd.execute = mock_execute = MagicMock()
     base_cmd.format_output = mock_format_output = MagicMock()
@@ -81,7 +81,7 @@ def test_base_cmd_format_output(output, exp_formatted_output, base_cmd):
 
 @patch("juju_spell.cli.base.parse_filter")
 @patch("juju_spell.cli.base.parse_comma_separated_str")
-def test_base_juju_cmd_argument_has_calls(
+def test_base_juju_cmd_fill_parser(
     mock_parse_comma_separated_str, mock_parse_filter, base_juju_cmd
 ):
     """Test add additional CLI arguments with BaseJujuCMD."""
@@ -186,27 +186,3 @@ def test_juju_write_cmd_run(
         juju_write_cmd.run(parsed_args)
 
     assert (mock_run.call_count != 0) == executed
-
-
-@pytest.mark.parametrize(
-    "parsed_args, executed",
-    [
-        ({"dry_run": False}, True),
-        ({"dry_run": True, "filter": None}, False),
-    ],
-)
-@patch("juju_spell.cli.base.BaseJujuCMD.execute")
-@patch("juju_spell.cli.base.get_filtered_config")
-def test_juju_cmd_dry_run(
-    mock_execute,
-    mock_get_filtered_config,
-    parsed_args,
-    executed,
-    base_juju_cmd,
-    test_config_dict,
-):
-    parsed_args = argparse.Namespace(**parsed_args)
-    base_juju_cmd.safe_parsed_args_output = MagicMock()
-    mock_get_filtered_config.return_value = test_config_dict
-    base_juju_cmd.run(parsed_args)
-    assert (base_juju_cmd.execute.call_count != 0) == executed

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -27,6 +27,18 @@ class TestBaseJujuCommand:
         assert test_juju_command.logger.name == test_juju_command.name
 
     @pytest.mark.asyncio
+    async def test_dry_run(self, test_juju_command):
+        controller = mock.MagicMock()
+        controller.controller_uuid = "abc"
+        test_juju_command.execute.__doc__ = "exec_doc"
+        result = await test_juju_command.dry_run(controller)
+        assert result.success
+        assert result.output == {
+            "target": "abc",
+            "command_doc": "exec_doc",
+        }
+
+    @pytest.mark.asyncio
     async def test_pre_check(self, test_juju_command):
         """Test pre_check function."""
         controller = mock.MagicMock()


### PR DESCRIPTION
The function code of dry-run:

```python
  async def dry_run(self, controller: Controller, **kwargs) -> Optional[Result]:
        """Dry-run will output the necessary information of the target."""
        self.logger.info("%s running dry-run", controller.controller_uuid)
        return Result(
            success=True,
            output={
                "target": controller.controller_uuid,
                "command_doc": self.execute.__doc__,
            },
        )
```

It will run pre-check first then dry-run

```sh
python -m juju_spell ping --dry-run
[
 {
  "context": {
   "uuid": "9d3fb816-fb10-461a-8230-0845cb8afa11",
   "name": "remote1-local-lxc",
   "customer": "remote1"
  },
  "success": true,
  "output": {
   "target": "9d3fb816-fb10-461a-8230-0845cb8afa11",
   "command_doc": "Check if controller is connected."
  },
  "error": null
 },
 {
  "context": {
   "uuid": "5392d486-dcd0-483d-815a-af1c5acfab1c",
   "name": "remote2-local-lxc",
   "customer": "remote2"
  },
  "success": true,
  "output": {
   "target": "5392d486-dcd0-483d-815a-af1c5acfab1c",
   "command_doc": "Check if controller is connected."
  },
  "error": null
 }
]                               
```