### PR TITLE
Refactor/connection config

### DIFF
--- a/juju_spell/assignment/runner.py
+++ b/juju_spell/assignment/runner.py
@@ -56,9 +56,8 @@ async def run_serial(
         results(Dict): Controller dict with result.
     """
     results: RESULTS_TYPE = []
-    port_range = config.connection.get("port-range")
     for controller_config in config.controllers:
-        controller = await get_controller(controller_config, port_range)
+        controller = await get_controller(controller_config)
         logger.debug("%s running in serial", controller.controller_uuid)
         command_kwargs = vars(parsed_args)
         command_kwargs["controller_config"] = controller_config

--- a/juju_spell/config.py
+++ b/juju_spell/config.py
@@ -77,7 +77,7 @@ class PortRange(String):
     """A template specific for port range."""
 
     def convert(self, value: Any, view: confuse.ConfigView) -> range:
-        """Check and convert port-range string to tuple."""
+        """Check and convert port_range string to tuple."""
         value = super().convert(value, view)
         start_port, end_port = value.split(":")
         return range(int(start_port), int(end_port))
@@ -137,23 +137,18 @@ JUJUSPELL_CONTROLLER_TEMPLATE = ControllerDict(
                             String(DESTINATION_REGEX, "Invalid jump definition")
                         )
                     ),
+                    "port_range": confuse.Optional(
+                        PortRange(
+                            PORT_RANGE,
+                            "Invalid port_range definition",
+                        )
+                    ),
                 }
             )
         ),
     }
 )
 
-JUJUSPELL_CONECTION_TEMPLATE = confuse.MappingTemplate(
-    {
-        "port-range": confuse.Optional(
-            PortRange(
-                PORT_RANGE,
-                "Invalid port-range definition",
-                default=DEFAULT_PORT_RANGE,
-            )
-        ),
-    }
-)
 
 JUJU_DEFAULT_CONTROLLER_DICT = {
     "uuid": confuse.Optional(String(UUID_REGEX, "Invalid uuid definition")),
@@ -205,11 +200,17 @@ JUJU_DEFAULT_CONTROLLER_DICT = {
                         )
                     )
                 ),
+                "port_range": confuse.Optional(
+                    PortRange(
+                        PORT_RANGE,
+                        "Invalid port_range definition",
+                    ),
+                    default=DEFAULT_PORT_RANGE,
+                ),
             }
         )
     ),
 }
-
 
 JUJUSPELL_DEFAULT_CONFIG_TEMPLATE = confuse.MappingTemplate(
     {
@@ -221,7 +222,6 @@ JUJUSPELL_DEFAULT_CONFIG_TEMPLATE = confuse.MappingTemplate(
                 ),
             }
         ),
-        "connection": confuse.Optional(JUJUSPELL_CONECTION_TEMPLATE),
         "controllers": confuse.Optional(
             confuse.Sequence(
                 # uuid and name are required, else is optional
@@ -233,7 +233,6 @@ JUJUSPELL_DEFAULT_CONFIG_TEMPLATE = confuse.MappingTemplate(
 
 JUJUSPELL_CONFIG_TEMPLATE = confuse.MappingTemplate(
     {
-        "connection": JUJUSPELL_CONECTION_TEMPLATE,
         "controllers": confuse.Sequence(JUJUSPELL_CONTROLLER_TEMPLATE),
     }
 )
@@ -244,6 +243,7 @@ class Connection:
     destination: str
     jumps: Optional[List[str]] = None
     subnets: Optional[List[str]] = None
+    port_range: Optional[range] = DEFAULT_PORT_RANGE
 
 
 @dataclasses.dataclass
@@ -269,7 +269,6 @@ class Controller:
 @dataclasses.dataclass
 class Config:
     controllers: List[Controller]
-    connection: Optional[Dict[str, Any]] = None
 
 
 def validate_source_match_template(

--- a/juju_spell/connections/manager.py
+++ b/juju_spell/connections/manager.py
@@ -12,7 +12,6 @@ from juju_spell.config import Controller
 from juju_spell.connections.network import BaseConnection, get_connection
 from juju_spell.settings import (
     DEFAULT_CONNECTIN_TIMEOUT,
-    DEFAULT_PORT_RANGE,
     DEFAULT_RETRY_BACKOFF,
     DEFUALT_MAX_FRAME_SIZE,
 )
@@ -129,13 +128,13 @@ class ConnectManager(object):
         return self._connections
 
     async def _connect(
-        self, controller_config: Controller, port_range: range, sshuttle: bool = False
+        self, controller_config: Controller, sshuttle: bool = False
     ) -> juju.Controller:
         """Prepare connection to Controller and return it."""
         logger.info("getting a new connection to controller %s", controller_config.name)
         controller = juju.Controller(max_frame_size=DEFUALT_MAX_FRAME_SIZE)
         controller_endpoint, connection_process = get_connection(
-            controller_config, port_range, sshuttle
+            controller_config, sshuttle
         )
         connection_process.connect()
         self.connections[controller_config.name] = Connection(
@@ -168,7 +167,6 @@ class ConnectManager(object):
     async def get_controller(
         self,
         controller_config: Controller,
-        port_range: range = DEFAULT_PORT_RANGE,
         sshuttle: bool = False,
         reconnect: bool = False,
     ) -> juju.Controller:
@@ -186,4 +184,4 @@ class ConnectManager(object):
         elif connection and reconnect:
             await connection.controller.disconnect()
 
-        return await self._connect(controller_config, port_range, sshuttle)
+        return await self._connect(controller_config, sshuttle)

--- a/juju_spell/connections/network.py
+++ b/juju_spell/connections/network.py
@@ -6,7 +6,6 @@ import subprocess
 from typing import List, Optional, Tuple
 
 from juju_spell.config import Controller
-from juju_spell.settings import DEFAULT_PORT_RANGE
 
 logger = logging.getLogger(__name__)
 
@@ -212,7 +211,6 @@ class SshuttleSubprocess(BaseSubprocessConnection):
 
 def get_connection(
     controller_config: Controller,
-    port_range: range = DEFAULT_PORT_RANGE,
     sshuttle: bool = False,
 ) -> Tuple[str, BaseConnection]:
     """Get connection."""
@@ -220,7 +218,7 @@ def get_connection(
     process = EmptyConnection()  # controller has direct access
 
     if controller_config.connection and not sshuttle:
-        port = get_free_tcp_port(port_range)
+        port = get_free_tcp_port(controller_config.connection.port_range)
         controller_endpoint = f"localhost:{port}"
         process = SshPortForwardSubprocess(
             controller_endpoint,

--- a/tests/unit/assignment/test_runner.py
+++ b/tests/unit/assignment/test_runner.py
@@ -131,9 +131,7 @@ async def test_run_serial(mock_get_result, mock_get_controller, steps, parsed_ar
     assert result == exp_result
 
     for controller_config, pre_check, dry_run, run_output, exp_output in steps:
-        mock_get_controller.assert_has_awaits(
-            [mock.call(controller_config, config.connection.get.return_value)]
-        )
+        mock_get_controller.assert_has_awaits([mock.call(controller_config)])
 
         command_kwargs = vars(parsed_args)
         command_kwargs["controller_config"] = controller_config

--- a/tests/unit/connections/test_manager.py
+++ b/tests/unit/connections/test_manager.py
@@ -158,7 +158,6 @@ class TestConnectManager(unittest.IsolatedAsyncioTestCase):
     async def test_connect(self, mock_controller_direct_connection, mock_controller):
         """Test connection with direct access."""
         config = self.controller_config_2
-        port_range = range(17071, 17170)
         exp_endpoint = "localhost:17071"
 
         mocked_controller = mock_controller.return_value = AsyncMock()
@@ -166,8 +165,8 @@ class TestConnectManager(unittest.IsolatedAsyncioTestCase):
             "juju_spell.connections.manager.get_connection"
         ) as mock_get_connection:
             mock_get_connection.return_value = exp_endpoint, MagicMock()
-            controller = await self.connect_manager._connect(config, port_range)
-            mock_get_connection.assert_called_once_with(config, port_range, False)
+            controller = await self.connect_manager._connect(config)
+            mock_get_connection.assert_called_once_with(config, False)
 
         assert controller == mocked_controller
         mock_controller_direct_connection.assert_called_once_with(
@@ -213,7 +212,7 @@ class TestConnectManager(unittest.IsolatedAsyncioTestCase):
 
         controller = await self.connect_manager.get_controller(config, reconnect=False)
 
-        mock_connect.assert_called_once_with(config, range(17071, 17170), False)
+        mock_connect.assert_called_once_with(config, False)
         assert controller == mock_connect.return_value
 
     async def test_get_controller_reconnect(self):
@@ -226,7 +225,7 @@ class TestConnectManager(unittest.IsolatedAsyncioTestCase):
         controller = await self.connect_manager.get_controller(config, reconnect=True)
 
         mocked_connection.controller.disconnect.assert_called_once()
-        mock_connect.assert_called_once_with(config, range(17071, 17170), False)
+        mock_connect.assert_called_once_with(config, False)
         assert controller == mock_connect.return_value
 
     async def test_get_controller_auto_reconnect(self):
@@ -240,7 +239,7 @@ class TestConnectManager(unittest.IsolatedAsyncioTestCase):
 
         controller = await self.connect_manager.get_controller(config, reconnect=False)
 
-        mock_connect.assert_called_once_with(config, range(17071, 17170), False)
+        mock_connect.assert_called_once_with(config, False)
         assert controller == mock_connect.return_value
 
     async def test_get_controller_existing_controller(self):


### PR DESCRIPTION
Move connection from top layer info controller's config.

The config format is really confuse people after we have the default config. We shouldn't allow two different way to provide the default.

The PR is following PR after #57 