### PR TITLE
feat: Enable user command

### DIFF
--- a/juju_spell/cli/enable_user.py
+++ b/juju_spell/cli/enable_user.py
@@ -1,0 +1,70 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import textwrap
+
+from craft_cli.dispatcher import _CustomArgumentParser
+
+from juju_spell.cli.base import JujuWriteCMD
+from juju_spell.commands.enable_user import EnableUserCommand
+
+
+class EnableUserCMD(JujuWriteCMD):
+    """Enable user command."""
+
+    name = "enable-user"
+    help_msg = "add juju user to remote controller"
+    overview = textwrap.dedent(
+        """
+        The command will enable user for controller.
+
+        Example:
+        $ juju-spell enable_user --user newuser
+        Continue on cmd: enable-user parsed_args: Namespace(dry_run=False,
+        no_confirm=False, run_type='serial',filter='', models=None,
+        user='newuser-abc')[Y/n]: Y
+        [
+         {
+          "context": {
+           "uuid": "e9fe93a8-b705-4067-8f30-6eec183eeb4f",
+           "name": "controller1",
+           "customer": "Gandalf"
+          },
+          "success": true,
+          "output": {
+           "results": [
+            {
+             "error": null,
+             "unknown_fields": {}
+            }
+           ],
+           "unknown_fields": {}
+          },
+          "error": null
+         },
+        ]
+        """
+    )
+
+    command = EnableUserCommand
+
+    def fill_parser(self, parser: _CustomArgumentParser) -> None:
+        super().fill_parser(parser=parser)
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="username to enable",
+            required=True,
+        )

--- a/juju_spell/commands/enable_user.py
+++ b/juju_spell/commands/enable_user.py
@@ -1,6 +1,6 @@
 # -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
 #
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 3 as
@@ -13,22 +13,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from juju.controller import Controller
 
-"""JujuSpell cli commands."""
-from .add_user import AddUserCMD
-from .enable_user import EnableUserCMD
-from .grant import GrantCMD
-from .ping import PingCMD
-from .remove_user import RemoveUserCMD
-from .show_controller import ShowControllerInformationCMD
-from .status import StatusCMD
+from juju_spell.commands.base import BaseJujuCommand
 
-__all__ = [
-    "AddUserCMD",
-    "EnableUserCMD",
-    "GrantCMD",
-    "RemoveUserCMD",
-    "PingCMD",
-    "StatusCMD",
-    "ShowControllerInformationCMD",
-]
+__all__ = ["EnableUserCommand"]
+
+
+class EnableUserCommand(BaseJujuCommand):
+    """Enable user."""
+
+    async def execute(self, controller: Controller, **kwargs) -> bool:
+        """Execute."""
+        result: bool = await controller.enable_user(username=kwargs["user"])
+        return result

--- a/tests/unit/cli/test_cli_enable_user.py
+++ b/tests/unit/cli/test_cli_enable_user.py
@@ -1,0 +1,15 @@
+from unittest import mock
+
+from juju_spell.cli.enable_user import EnableUserCMD
+
+
+def test_enable_user_cmd_fill_parser():
+    """Test add additional CLI arguments with BaseCMD."""
+    parser = mock.MagicMock()
+    EnableUserCMD(config=None).fill_parser(parser)
+
+    parser.add_argument.assert_has_calls(
+        [
+            mock.call("--user", type=str, help="username to enable", required=True),
+        ]
+    )

--- a/tests/unit/commands/test_enable_user.py
+++ b/tests/unit/commands/test_enable_user.py
@@ -1,0 +1,16 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from juju_spell.commands.enable_user import EnableUserCommand
+
+
+@pytest.mark.asyncio
+async def test_enable_user_execute():
+    cmd = EnableUserCommand()
+
+    mock_conn = AsyncMock()
+
+    await cmd.execute(mock_conn, **{"user": "new-user"})
+
+    mock_conn.enable_user.assert_awaited_once_with(**{"username": "new-user"})


### PR DESCRIPTION
Example:

```sh
$ python -m juju_spell enable-user --user newuser-abc                                        
Continue on cmd: enable-user parsed_args: Namespace(dry_run=False, no_confirm=False, run_type='serial', filter='', models=None, user='newuser-abc')[Y/n]: Y
[
 {
  "context": {
   "uuid": "9d3fb816-fb10-461a-8230-0845cb8afa11",
   "name": "remote1-local-lxc",
   "customer": "remote1"
  },
  "success": true,
  "output": {
   "results": [
    {
     "error": null,
     "unknown_fields": {}
    }
   ],
   "unknown_fields": {}
  },
  "error": null
 },
 {
  "context": {
   "uuid": "5392d486-dcd0-483d-815a-af1c5acfab1c",
   "name": "remote2-local-lxc",
   "customer": "remote2"
  },
  "success": true,
  "output": {
   "results": [
    {
     "error": null,
     "unknown_fields": {}
    }
   ],
   "unknown_fields": {}
  },
  "error": null
 }
]                                                
```