### PR TITLE
Add caching feature to list models

### DIFF
--- a/juju_spell/cli/list_models.py
+++ b/juju_spell/cli/list_models.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Command entrypoint for ControllerInformationCommand."""
+"""Command entrypoint for ListModelsCommand."""
 import os
 import textwrap
 from datetime import datetime

--- a/juju_spell/cli/list_models.py
+++ b/juju_spell/cli/list_models.py
@@ -100,13 +100,15 @@ class ListModelsCMD(JujuReadCMD):
                 "output": {
                     "uuid": "03ascsb2-bba8-477b-854e-5715a7sb320a",
                     "name": "xxx-serverstack",
-                    "models": [
-                        "controller",
-                        "model-a",
-                        "model-b",
-                        "model-c"
-                    ],
-                    "refresh": true,
+                    "data": {
+                        "models": [
+                            "controller",
+                            "model-a",
+                            "model-b",
+                            "model-c"
+                        ],
+                        "refresh": true,
+                    },
                     "timestamp": 1078416000.0
                 },
                 "error": null
@@ -118,13 +120,14 @@ class ListModelsCMD(JujuReadCMD):
         controller_models_mapping = {}
 
         heading = ""
-        for outputs in retval:
-            controller_name = outputs["context"]["name"]
-            models = outputs["output"]["models"]
-            refresh = outputs["output"]["refresh"]
+        for content in retval:
+            output = content["output"]
+            controller_name = output["name"]
+            models = output["data"]["models"]
+            refresh = output["data"]["refresh"]
             controller_models_mapping[controller_name] = models
             if not refresh:
-                timestamp = float(outputs["output"]["timestamp"])
+                timestamp = float(output["timestamp"])
                 heading = WARNING_HEADING_TEMPLATE.format(
                     datetime.fromtimestamp(timestamp).strftime(DATETIME_FORMATTER)
                 )

--- a/juju_spell/cli/list_models.py
+++ b/juju_spell/cli/list_models.py
@@ -28,7 +28,8 @@ from juju_spell.cli.base import JujuReadCMD
 from juju_spell.commands.list_models import ListModelsCommand
 
 WARNING_HEADING_TEMPLATE = (
-    "Use --refresh option with this command to see the latest information.\n\n(Last updated: {})"
+    f"Use --refresh option with this command to see the latest information.{os.linesep*2}"
+    "(Last updated: {})"
 )
 DATETIME_FORMATTER = "%Y-%m-%d %H:%M:%S"
 
@@ -58,7 +59,7 @@ class ListModelsCMD(JujuReadCMD):
         $ juju-spell list-models
         Use --refresh option with this command to see the latest information.
 
-        (Last updated: 1970-01-01 00:00:00)
+        (Last updated: 2004-03-05 00:00:00)
 
         controller-a:
         - model-a
@@ -106,7 +107,7 @@ class ListModelsCMD(JujuReadCMD):
                         "model-c"
                     ],
                     "refresh": true,
-                    "timestamp": 1172969203.1
+                    "timestamp": 1078416000.0
                 },
                 "error": null
             }

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -17,12 +17,12 @@ class ListModelsCommand(BaseJujuCommand):
         self, controller: Controller, *args: Any, **kwargs: Any
     ) -> Dict[str, Union[List, bool]]:
         """List models from the local cache or from the controllers."""
-        outputs: Union[JujuSpellError, Dict[str, Any]] = {}
+        outputs: Union[None, Dict[str, Any]] = {}
 
         if not kwargs["refresh"]:
             outputs = load_cache_data(kwargs["controller_config"].uuid, self.logger)
 
-        if kwargs["refresh"] or isinstance(outputs, JujuSpellError):
+        if kwargs["refresh"] or outputs is None:
             models = list(
                 await self.get_filtered_model_names(
                     controller=controller,
@@ -55,13 +55,13 @@ def save_cache_data(
     return cache_data
 
 
-def load_cache_data(uuid: str, logger: Logger) -> Union[JujuSpellError, Dict[str, Any]]:
+def load_cache_data(uuid: str, logger: Logger) -> Union[None, Dict[str, Any]]:
     """Gracefully load cache data from default cache directory."""
+    cache_data = None
     error_message_template = "%s list models failed to load cache: %s."
     try:
         cache_data = load_from_cache(uuid)
         cache_data["refresh"] = False
     except JujuSpellError as error:
         logger.debug(error_message_template, uuid, str(error))
-        return JujuSpellError(error_message_template.format(uuid, str(error)))
     return cache_data

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -23,7 +23,7 @@ class ListModelsCommand(BaseJujuCommand):
             fname = f"{self.name}_{kwargs['controller_config'].uuid}"
             cache = load_cache_data(fname, self.logger, kwargs["controller_config"].uuid)
 
-        if kwargs["refresh"] or cache is None or cache.expired:
+        if kwargs["refresh"] or cache is None:
             models = list(
                 await self.get_filtered_model_names(
                     controller=controller,

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -7,7 +7,7 @@ from juju.controller import Controller
 
 from juju_spell.commands.base import BaseJujuCommand
 from juju_spell.exceptions import JujuSpellError
-from juju_spell.utils import load_from_cache, save_to_cache
+from juju_spell.utils import Cache, load_from_cache, save_to_cache
 
 
 class ListModelsCommand(BaseJujuCommand):
@@ -17,12 +17,13 @@ class ListModelsCommand(BaseJujuCommand):
         self, controller: Controller, *args: Any, **kwargs: Any
     ) -> Dict[str, Union[List, bool]]:
         """List models from the local cache or from the controllers."""
-        outputs: Union[None, Dict[str, Any]] = {}
+        cache: Union[None, Cache] = None
 
         if not kwargs["refresh"]:
-            outputs = load_cache_data(kwargs["controller_config"].uuid, self.logger)
+            fname = f"{self.name}_{kwargs['controller_config'].uuid}"
+            cache = load_cache_data(fname, self.logger)
 
-        if kwargs["refresh"] or outputs is None:
+        if kwargs["refresh"] or cache is None or cache.expired:
             models = list(
                 await self.get_filtered_model_names(
                     controller=controller,
@@ -30,38 +31,41 @@ class ListModelsCommand(BaseJujuCommand):
                     model_mappings=kwargs["controller_config"].model_mapping,
                 )
             )
-            outputs = save_cache_data(controller, models, kwargs["refresh"], self.logger)
+            cache = save_cache_data(controller, models, kwargs["refresh"], self.logger, self.name)
 
-        self.logger.debug("%s list models: %s", controller.controller_uuid, outputs["models"])
-        return outputs
+        self.logger.debug("%s list models: %s", controller.controller_uuid, cache.data["models"])
+        return cache.context
 
 
 def save_cache_data(
-    controller: Controller, models: List[str], refresh: bool, logger: Logger
-) -> Dict[str, Any]:
+    controller: Controller, models: List[str], refresh: bool, logger: Logger, command_name: str
+) -> Cache:
     """Gracefully save cache data to default cache directory."""
-    cache_data = {
-        "uuid": controller.controller_uuid,
-        "name": controller.controller_name,
-        "models": models,
-        "refresh": refresh,
-        "timestamp": time(),
-    }
+    cache = Cache(
+        uuid=controller.controller_uuid,
+        name=controller.controller_name,
+        data={
+            "models": models,
+            "refresh": refresh,
+        },
+        timestamp=time(),
+    )
+    fname = f"{command_name}_{controller.controller_uuid}"
     error_message_template = "%s list models failed to save cache: %s."
     try:
-        save_to_cache(cache_data, controller.controller_uuid)
+        save_to_cache(cache, fname)
     except JujuSpellError as error:
-        logger.debug(error_message_template, controller.controller_uuid, str(error))
-    return cache_data
+        logger.debug(error_message_template, fname, str(error))
+    return cache
 
 
-def load_cache_data(uuid: str, logger: Logger) -> Union[None, Dict[str, Any]]:
+def load_cache_data(fname: str, logger: Logger) -> Union[None, Cache]:
     """Gracefully load cache data from default cache directory."""
-    cache_data = None
+    cache = None
     error_message_template = "%s list models failed to load cache: %s."
     try:
-        cache_data = load_from_cache(uuid)
-        cache_data["refresh"] = False
+        cache = load_from_cache(fname)
+        cache.data["refresh"] = False
     except JujuSpellError as error:
-        logger.debug(error_message_template, uuid, str(error))
-    return cache_data
+        logger.debug(error_message_template, fname, str(error))
+    return cache

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -21,7 +21,7 @@ class ListModelsCommand(BaseJujuCommand):
 
         if not kwargs["refresh"]:
             fname = f"{self.name}_{kwargs['controller_config'].uuid}"
-            cache = load_cache_data(fname, self.logger)
+            cache = load_cache_data(fname, self.logger, kwargs["controller_config"].uuid)
 
         if kwargs["refresh"] or cache is None or cache.expired:
             models = list(
@@ -54,18 +54,22 @@ def save_cache_data(
     error_message_template = "%s list models failed to save cache: %s."
     try:
         save_to_cache(cache, fname)
+        logger.debug(
+            "%s list models: save result to cache `%s`", controller.controller_uuid, str(fname)
+        )
     except JujuSpellError as error:
-        logger.debug(error_message_template, fname, str(error))
+        logger.warning(error_message_template, controller.controller_uuid, str(error))
     return cache
 
 
-def load_cache_data(fname: str, logger: Logger) -> Union[None, Cache]:
+def load_cache_data(fname: str, logger: Logger, uuid: str) -> Union[None, Cache]:
     """Gracefully load cache data from default cache directory."""
     cache = None
     error_message_template = "%s list models failed to load cache: %s."
     try:
         cache = load_from_cache(fname)
         cache.data["refresh"] = False
+        logger.debug("%s list models: load result from cache `%s`", uuid, str(fname))
     except JujuSpellError as error:
-        logger.debug(error_message_template, fname, str(error))
+        logger.warning(error_message_template, uuid, str(error))
     return cache

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -1,9 +1,13 @@
 """List models from the local cache or from the controllers."""
+from logging import Logger
+from time import time
 from typing import Any, Dict, List, Union
 
 from juju.controller import Controller
 
 from juju_spell.commands.base import BaseJujuCommand
+from juju_spell.exceptions import JujuSpellError
+from juju_spell.utils import load_from_cache, save_to_cache
 
 
 class ListModelsCommand(BaseJujuCommand):
@@ -13,7 +17,12 @@ class ListModelsCommand(BaseJujuCommand):
         self, controller: Controller, *args: Any, **kwargs: Any
     ) -> Dict[str, Union[List, bool]]:
         """List models from the local cache or from the controllers."""
-        if kwargs["refresh"]:
+        outputs: Union[JujuSpellError, Dict[str, Any]] = {}
+
+        if not kwargs["refresh"]:
+            outputs = load_cache_data(kwargs["controller_config"].uuid, self.logger)
+
+        if kwargs["refresh"] or isinstance(outputs, JujuSpellError):
             models = list(
                 await self.get_filtered_model_names(
                     controller=controller,
@@ -21,9 +30,38 @@ class ListModelsCommand(BaseJujuCommand):
                     model_mappings=kwargs["controller_config"].model_mapping,
                 )
             )
-        else:
-            models = ["TODO: read from cache; not implemented."]
+            outputs = save_cache_data(controller, models, kwargs["refresh"], self.logger)
 
-        outputs = {"refresh": kwargs["refresh"], "models": models}
         self.logger.debug("%s list models: %s", controller.controller_uuid, outputs["models"])
         return outputs
+
+
+def save_cache_data(
+    controller: Controller, models: List[str], refresh: bool, logger: Logger
+) -> Dict[str, Any]:
+    """Gracefully save cache data to default cache directory."""
+    cache_data = {
+        "uuid": controller.controller_uuid,
+        "name": controller.controller_name,
+        "models": models,
+        "refresh": refresh,
+        "timestamp": time(),
+    }
+    error_message_template = "%s list models failed to save cache: %s."
+    try:
+        save_to_cache(cache_data, controller.controller_uuid)
+    except JujuSpellError as error:
+        logger.debug(error_message_template, controller.controller_uuid, str(error))
+    return cache_data
+
+
+def load_cache_data(uuid: str, logger: Logger) -> Union[JujuSpellError, Dict[str, Any]]:
+    """Gracefully load cache data from default cache directory."""
+    error_message_template = "%s list models failed to load cache: %s."
+    try:
+        cache_data = load_from_cache(uuid)
+        cache_data["refresh"] = False
+    except JujuSpellError as error:
+        logger.debug(error_message_template, uuid, str(error))
+        return JujuSpellError(error_message_template.format(uuid, str(error)))
+    return cache_data

--- a/juju_spell/settings.py
+++ b/juju_spell/settings.py
@@ -28,6 +28,7 @@ PERSONAL_CONFIG_PATH = pathlib.Path(
         "JUJUSPELL_PERSONAL_CONFIG", pathlib.Path(JUJUSPELL_DATA / "config.personal.yaml")
     )
 )
+DEFAULT_CACHE_DIR = pathlib.Path(JUJUSPELL_DATA / "caches")
 DEFAULT_PORT_RANGE = range(17071, 17170)
 DEFAULT_RETRY_BACKOFF = 1.5  # seconds
 DEFAULT_CONNECTION_TIMEOUT = 60  # seconds

--- a/juju_spell/utils.py
+++ b/juju_spell/utils.py
@@ -186,6 +186,7 @@ def save_to_cache(cache: Cache, name: Union[str, Path]) -> None:
     try:
         with open(fname, "w", encoding="UTF-8") as file:
             data = yaml.safe_dump(cache.context)
+            logger.info("save cache file to %s", str(fname))
             file.write(data)
     except PermissionError as error:
         raise JujuSpellError(f"permission denied to write to file `{fname}`.") from error
@@ -199,6 +200,7 @@ def load_from_cache(name: Union[str, Path]) -> Cache:
     try:
         with open(fname, "r", encoding="UTF-8") as file:
             data = yaml.safe_load(file)
+            logger.info("load cache file from %s", str(fname))
             return Cache(**data)
     except FileNotFoundError as error:
         raise JujuSpellError(f"`{fname}` does not exists.") from error

--- a/juju_spell/utils.py
+++ b/juju_spell/utils.py
@@ -20,7 +20,6 @@ import logging
 import secrets
 from collections import defaultdict
 from pathlib import Path
-from time import time
 from typing import Any, Dict, Iterable, List, Union
 
 import yaml
@@ -29,27 +28,6 @@ from juju_spell.exceptions import JujuSpellError
 from juju_spell.settings import DEFAULT_CACHE_DIR
 
 logger = logging.getLogger(__name__)
-
-
-class CachePolicy(dict):
-    """Base class for cache policy."""
-
-    def __init__(self, **kwargs: Any):
-        """Initialize cache policy."""
-        super().__init__(**kwargs)
-
-    @classmethod
-    def init_from_config(cls, cache_config: Any) -> None:
-        """Load the policy from a user defined policy config."""
-        # raise NotImplementedError("Init from cache config file is not supported yet.")
-
-
-class DefaultCachePolicy(CachePolicy):
-    """A default cache policy used by any cache data."""
-
-    def __init__(self, ttl: float, auto_refresh: bool = True):
-        """Initialize default cache policy."""
-        super().__init__(ttl=ttl, auto_refresh=auto_refresh)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -64,13 +42,6 @@ class CacheContext:
 
 class Cache(CacheContext):
     """A cache for command's output with cache policy."""
-
-    policy: DefaultCachePolicy = DefaultCachePolicy(ttl=3600, auto_refresh=True)
-
-    @property
-    def expired(self) -> bool:
-        """Check if the cache is expired or not."""
-        return self.timestamp + self.policy.get("ttl", 3600) < time()
 
     @property
     def context(self) -> Dict[str, Any]:

--- a/tests/unit/cli/test_cli_list_models.py
+++ b/tests/unit/cli/test_cli_list_models.py
@@ -1,10 +1,15 @@
 import os
+from datetime import datetime
 from unittest import mock
 
 import pytest
 import yaml
 
-from juju_spell.cli.list_models import WARNING_HEADING, ListModelsCMD
+from juju_spell.cli.list_models import (
+    DATETIME_FORMATTER,
+    WARNING_HEADING_TEMPLATE,
+    ListModelsCMD,
+)
 
 
 def test_fill_parser():
@@ -18,10 +23,7 @@ def test_fill_parser():
                 "--refresh",
                 default=False,
                 action="store_true",
-                help=(
-                    "This will force refresh all models from the controllers. (TODO: to"
-                    " be implemented)"
-                ),
+                help="This will force refresh all models from the controllers.",
             ),
         ]
     )
@@ -40,8 +42,11 @@ def test_fill_parser():
                     },
                     "success": True,
                     "output": {
+                        "uuid": "03ascsb2-bba8-477b-854e-5715a7sb320a",
+                        "name": "xxx-serverstack",
                         "refresh": True,
                         "models": ["controller", "model-a", "model-b", "model-c"],
+                        "timestamp": 1678256395.5965466,
                     },
                     "error": None,
                 }
@@ -60,12 +65,17 @@ def test_fill_parser():
                     "success": True,
                     "output": {
                         "refresh": False,
+                        "uuid": "03ascsb2-bba8-477b-854e-5715a7sb320a",
+                        "name": "xxx-serverstack",
                         "models": ["controller", "model-a", "model-b"],
+                        "timestamp": 1678256395.5965466,
                     },
                     "error": None,
                 }
             ],
-            WARNING_HEADING,
+            WARNING_HEADING_TEMPLATE.format(
+                datetime.fromtimestamp(1678256395.5965466).strftime(DATETIME_FORMATTER)
+            ),
             {"yyy-serverstack": ["controller", "model-a", "model-b"]},
         ),
     ],

--- a/tests/unit/cli/test_cli_list_models.py
+++ b/tests/unit/cli/test_cli_list_models.py
@@ -44,8 +44,10 @@ def test_fill_parser():
                     "output": {
                         "uuid": "03ascsb2-bba8-477b-854e-5715a7sb320a",
                         "name": "xxx-serverstack",
-                        "refresh": True,
-                        "models": ["controller", "model-a", "model-b", "model-c"],
+                        "data": {
+                            "refresh": True,
+                            "models": ["controller", "model-a", "model-b", "model-c"],
+                        },
                         "timestamp": 1678256395.5965466,
                     },
                     "error": None,
@@ -64,10 +66,12 @@ def test_fill_parser():
                     },
                     "success": True,
                     "output": {
-                        "refresh": False,
                         "uuid": "03ascsb2-bba8-477b-854e-5715a7sb320a",
-                        "name": "xxx-serverstack",
-                        "models": ["controller", "model-a", "model-b"],
+                        "name": "yyy-serverstack",
+                        "data": {
+                            "refresh": False,
+                            "models": ["controller", "model-a", "model-b"],
+                        },
                         "timestamp": 1678256395.5965466,
                     },
                     "error": None,

--- a/tests/unit/commands/test_list_models.py
+++ b/tests/unit/commands/test_list_models.py
@@ -112,7 +112,8 @@ def test_20_save_cache_data_okay(mock_save_to_cache):
 
     list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger, Mock())
 
-    mock_logger.debug.assert_not_called()
+    mock_logger.debug.assert_called_once()
+    mock_logger.warning.assert_not_called()
     mock_save_to_cache.assert_called_once()
 
 
@@ -125,30 +126,35 @@ def test_21_save_cache_data_fail(mock_save_to_cache):
     mock_save_to_cache.side_effect = JujuSpellError()
     list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger, Mock())
 
-    mock_logger.debug.assert_called_once()
+    mock_logger.debug.assert_not_called()
+    mock_logger.warning.assert_called_once()
     mock_save_to_cache.assert_called_once()
 
 
 @patch("juju_spell.commands.list_models.load_from_cache")
 def test_30_load_cache_data_okay(mock_load_from_cache):
     """Test load_cache_data function when load cache is okay."""
+    mock_uuid = Mock()
     mock_name = Mock()
     mock_logger = Mock()
 
-    list_models.load_cache_data(mock_name, mock_logger)
+    list_models.load_cache_data(mock_name, mock_logger, mock_uuid)
 
-    mock_logger.debug.assert_not_called()
+    mock_logger.debug.assert_called_once()
+    mock_logger.warning.assert_not_called()
     mock_load_from_cache.assert_called_once()
 
 
 @patch("juju_spell.commands.list_models.load_from_cache")
 def test_31_load_cache_data_fail(mock_load_from_cache):
     """Test load_cache_data function when load cache is not okay."""
+    mock_uuid = Mock()
     mock_name = Mock()
     mock_logger = Mock()
 
     mock_load_from_cache.side_effect = JujuSpellError()
-    list_models.load_cache_data(mock_name, mock_logger)
+    list_models.load_cache_data(mock_name, mock_logger, mock_uuid)
 
-    mock_logger.debug.assert_called_once()
+    mock_logger.debug.assert_not_called()
+    mock_logger.warning.assert_called_once()
     mock_load_from_cache.assert_called_once()

--- a/tests/unit/commands/test_list_models.py
+++ b/tests/unit/commands/test_list_models.py
@@ -32,32 +32,6 @@ async def test_execute_with_refresh(mock_load_from_cache, mock_save_to_cache):
 @pytest.mark.asyncio
 @patch("juju_spell.commands.list_models.save_to_cache")
 @patch("juju_spell.commands.list_models.load_from_cache")
-async def test_10_execute_without_refresh_has_cache(mock_load_from_cache, mock_save_to_cache):
-    """Test execute function for ListModelsCommand without --refresh and have existing cache."""
-    mock_controller = AsyncMock()
-    mock_controller_config = Mock()
-    list_models = ListModelsCommand()
-
-    mock_cache = Mock()
-    mock_cache.data = {"models": []}
-    mock_cache.expired = False
-    mock_load_from_cache.return_value = mock_cache
-
-    await list_models.execute(
-        controller=mock_controller,
-        refresh=False,
-        controller_config=mock_controller_config,
-        models=None,
-    )
-
-    mock_save_to_cache.assert_not_called()
-    mock_load_from_cache.assert_called_once()
-    mock_controller.list_models.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-@patch("juju_spell.commands.list_models.save_to_cache")
-@patch("juju_spell.commands.list_models.load_from_cache")
 async def test_11_execute_without_refresh_no_cache(mock_load_from_cache, mock_save_to_cache):
     """Test execute function for ListModelsCommand without --refresh and no existing cache."""
     mock_controller = AsyncMock()
@@ -65,32 +39,6 @@ async def test_11_execute_without_refresh_no_cache(mock_load_from_cache, mock_sa
     list_models = ListModelsCommand()
 
     mock_load_from_cache.side_effect = JujuSpellError()
-
-    await list_models.execute(
-        controller=mock_controller,
-        refresh=False,
-        controller_config=mock_controller_config,
-        models=None,
-    )
-
-    mock_save_to_cache.assert_called_once()
-    mock_load_from_cache.assert_called_once()
-    mock_controller.list_models.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-@patch("juju_spell.commands.list_models.save_to_cache")
-@patch("juju_spell.commands.list_models.load_from_cache")
-async def test_12_execute_without_refresh_expired_cache(mock_load_from_cache, mock_save_to_cache):
-    """Test execute function for ListModelsCommand without --refresh and have expired cache."""
-    mock_controller = AsyncMock()
-    mock_controller_config = Mock()
-    list_models = ListModelsCommand()
-
-    mock_cache = Mock()
-    mock_cache.data = {"models": []}
-    mock_cache.expired = True
-    mock_load_from_cache.return_value = mock_cache
 
     await list_models.execute(
         controller=mock_controller,

--- a/tests/unit/commands/test_list_models.py
+++ b/tests/unit/commands/test_list_models.py
@@ -16,7 +16,7 @@ async def test_execute_with_refresh(mock_load_from_cache, mock_save_to_cache):
     mock_controller_config = Mock()
     list_models = ListModelsCommand()
 
-    outputs = await list_models.execute(
+    context = await list_models.execute(
         controller=mock_controller,
         refresh=True,
         controller_config=mock_controller_config,
@@ -26,7 +26,7 @@ async def test_execute_with_refresh(mock_load_from_cache, mock_save_to_cache):
     mock_save_to_cache.assert_called_once()
     mock_load_from_cache.assert_not_called()
     mock_controller.list_models.assert_awaited_once()
-    assert outputs["refresh"] is True
+    assert context["data"]["refresh"] is True
 
 
 @pytest.mark.asyncio
@@ -38,7 +38,10 @@ async def test_10_execute_without_refresh_has_cache(mock_load_from_cache, mock_s
     mock_controller_config = Mock()
     list_models = ListModelsCommand()
 
-    mock_load_from_cache.return_value = {"models": []}
+    mock_cache = Mock()
+    mock_cache.data = {"models": []}
+    mock_cache.expired = False
+    mock_load_from_cache.return_value = mock_cache
 
     await list_models.execute(
         controller=mock_controller,
@@ -75,13 +78,39 @@ async def test_11_execute_without_refresh_no_cache(mock_load_from_cache, mock_sa
     mock_controller.list_models.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+@patch("juju_spell.commands.list_models.save_to_cache")
+@patch("juju_spell.commands.list_models.load_from_cache")
+async def test_12_execute_without_refresh_expired_cache(mock_load_from_cache, mock_save_to_cache):
+    """Test execute function for ListModelsCommand without --refresh and have expired cache."""
+    mock_controller = AsyncMock()
+    mock_controller_config = Mock()
+    list_models = ListModelsCommand()
+
+    mock_cache = Mock()
+    mock_cache.data = {"models": []}
+    mock_cache.expired = True
+    mock_load_from_cache.return_value = mock_cache
+
+    await list_models.execute(
+        controller=mock_controller,
+        refresh=False,
+        controller_config=mock_controller_config,
+        models=None,
+    )
+
+    mock_save_to_cache.assert_called_once()
+    mock_load_from_cache.assert_called_once()
+    mock_controller.list_models.assert_awaited_once()
+
+
 @patch("juju_spell.commands.list_models.save_to_cache")
 def test_20_save_cache_data_okay(mock_save_to_cache):
     """Test save_cache_data function when save cache is okay."""
     mock_models = Mock()
     mock_logger = Mock()
 
-    list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger)
+    list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger, Mock())
 
     mock_logger.debug.assert_not_called()
     mock_save_to_cache.assert_called_once()
@@ -94,7 +123,7 @@ def test_21_save_cache_data_fail(mock_save_to_cache):
     mock_logger = Mock()
 
     mock_save_to_cache.side_effect = JujuSpellError()
-    list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger)
+    list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger, Mock())
 
     mock_logger.debug.assert_called_once()
     mock_save_to_cache.assert_called_once()
@@ -103,10 +132,10 @@ def test_21_save_cache_data_fail(mock_save_to_cache):
 @patch("juju_spell.commands.list_models.load_from_cache")
 def test_30_load_cache_data_okay(mock_load_from_cache):
     """Test load_cache_data function when load cache is okay."""
-    mock_uuid = Mock()
+    mock_name = Mock()
     mock_logger = Mock()
 
-    list_models.load_cache_data(mock_uuid, mock_logger)
+    list_models.load_cache_data(mock_name, mock_logger)
 
     mock_logger.debug.assert_not_called()
     mock_load_from_cache.assert_called_once()
@@ -115,11 +144,11 @@ def test_30_load_cache_data_okay(mock_load_from_cache):
 @patch("juju_spell.commands.list_models.load_from_cache")
 def test_31_load_cache_data_fail(mock_load_from_cache):
     """Test load_cache_data function when load cache is not okay."""
-    mock_uuid = Mock()
+    mock_name = Mock()
     mock_logger = Mock()
 
     mock_load_from_cache.side_effect = JujuSpellError()
-    list_models.load_cache_data(mock_uuid, mock_logger)
+    list_models.load_cache_data(mock_name, mock_logger)
 
     mock_logger.debug.assert_called_once()
     mock_load_from_cache.assert_called_once()

--- a/tests/unit/commands/test_list_models.py
+++ b/tests/unit/commands/test_list_models.py
@@ -1,12 +1,16 @@
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from juju_spell.commands import list_models
 from juju_spell.commands.list_models import ListModelsCommand
+from juju_spell.exceptions import JujuSpellError
 
 
 @pytest.mark.asyncio
-async def test_execute_with_refresh():
+@patch("juju_spell.commands.list_models.save_to_cache")
+@patch("juju_spell.commands.list_models.load_from_cache")
+async def test_execute_with_refresh(mock_load_from_cache, mock_save_to_cache):
     """Test execute function for ListModelsCommand with --refresh."""
     mock_controller = AsyncMock()
     mock_controller_config = Mock()
@@ -19,24 +23,103 @@ async def test_execute_with_refresh():
         models=None,
     )
 
+    mock_save_to_cache.assert_called_once()
+    mock_load_from_cache.assert_not_called()
     mock_controller.list_models.assert_awaited_once()
     assert outputs["refresh"] is True
 
 
 @pytest.mark.asyncio
-async def test_execute_without_refresh():
-    """Test execute function for ListModelsCommand without --refresh."""
+@patch("juju_spell.commands.list_models.save_to_cache")
+@patch("juju_spell.commands.list_models.load_from_cache")
+async def test_10_execute_without_refresh_has_cache(mock_load_from_cache, mock_save_to_cache):
+    """Test execute function for ListModelsCommand without --refresh and have existing cache."""
     mock_controller = AsyncMock()
     mock_controller_config = Mock()
     list_models = ListModelsCommand()
 
-    outputs = await list_models.execute(
+    mock_load_from_cache.return_value = {"models": []}
+
+    await list_models.execute(
         controller=mock_controller,
         refresh=False,
         controller_config=mock_controller_config,
         models=None,
     )
 
+    mock_save_to_cache.assert_not_called()
+    mock_load_from_cache.assert_called_once()
     mock_controller.list_models.assert_not_awaited()
-    assert outputs["refresh"] is False
-    # TODO: test caching logic
+
+
+@pytest.mark.asyncio
+@patch("juju_spell.commands.list_models.save_to_cache")
+@patch("juju_spell.commands.list_models.load_from_cache")
+async def test_11_execute_without_refresh_no_cache(mock_load_from_cache, mock_save_to_cache):
+    """Test execute function for ListModelsCommand without --refresh and no existing cache."""
+    mock_controller = AsyncMock()
+    mock_controller_config = Mock()
+    list_models = ListModelsCommand()
+
+    mock_load_from_cache.side_effect = JujuSpellError()
+
+    await list_models.execute(
+        controller=mock_controller,
+        refresh=False,
+        controller_config=mock_controller_config,
+        models=None,
+    )
+
+    mock_save_to_cache.assert_called_once()
+    mock_load_from_cache.assert_called_once()
+    mock_controller.list_models.assert_awaited_once()
+
+
+@patch("juju_spell.commands.list_models.save_to_cache")
+def test_20_save_cache_data_okay(mock_save_to_cache):
+    """Test save_cache_data function when save cache is okay."""
+    mock_models = Mock()
+    mock_logger = Mock()
+
+    list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger)
+
+    mock_logger.debug.assert_not_called()
+    mock_save_to_cache.assert_called_once()
+
+
+@patch("juju_spell.commands.list_models.save_to_cache")
+def test_21_save_cache_data_fail(mock_save_to_cache):
+    """Test save_cache_data function when save cache is not okay."""
+    mock_models = Mock()
+    mock_logger = Mock()
+
+    mock_save_to_cache.side_effect = JujuSpellError()
+    list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger)
+
+    mock_logger.debug.assert_called_once()
+    mock_save_to_cache.assert_called_once()
+
+
+@patch("juju_spell.commands.list_models.load_from_cache")
+def test_30_load_cache_data_okay(mock_load_from_cache):
+    """Test load_cache_data function when load cache is okay."""
+    mock_uuid = Mock()
+    mock_logger = Mock()
+
+    list_models.load_cache_data(mock_uuid, mock_logger)
+
+    mock_logger.debug.assert_not_called()
+    mock_load_from_cache.assert_called_once()
+
+
+@patch("juju_spell.commands.list_models.load_from_cache")
+def test_31_load_cache_data_fail(mock_load_from_cache):
+    """Test load_cache_data function when load cache is not okay."""
+    mock_uuid = Mock()
+    mock_logger = Mock()
+
+    mock_load_from_cache.side_effect = JujuSpellError()
+    list_models.load_cache_data(mock_uuid, mock_logger)
+
+    mock_logger.debug.assert_called_once()
+    mock_load_from_cache.assert_called_once()


### PR DESCRIPTION
This MR add caching capability to `list-models` sub-command. It contains the following features:

- When run as `juju-spell list-models`
  - It tries to load the cached result of `list-models` from `DEFAULT_CACHE_DIR`, and if not found, it will fetch result from the controller and then save the result to the cache directory.
  - If cached result exist, it use the cache result and prepend a warning message to instruct user to run `--refresh` if necessary.
  - **[reverted, will be in the future PR]** If cached result exist but the cache is expired (based on the cache policy), it will fetch result from the controller and then save the result to the cache directory.
- When run as `juju-spell list-models --refresh`
  -  It will fetch result from the controller and then save the result to the cache directory.

However, due to #89 , the caching feature currently does not improve the speed significantly.