### PR TITLE
remove args from abstract execute

### DIFF
--- a/juju_spell/commands/add_user.py
+++ b/juju_spell/commands/add_user.py
@@ -28,7 +28,6 @@ class AddUserCommand(BaseJujuCommand):
     async def execute(
         self,
         controller: Controller,
-        *args: Any,
         overwrite: bool = False,
         **kwargs: Any,
     ) -> Union[Dict[str, str], Result]:

--- a/juju_spell/commands/base.py
+++ b/juju_spell/commands/base.py
@@ -133,7 +133,6 @@ class BaseJujuCommand(metaclass=ABCMeta):
     async def execute(
         self,
         controller: Controller,
-        *args: Any,
         **kwargs: Any,
     ) -> Any:  # pragma: no cover
         """Execute function.

--- a/juju_spell/commands/config.py
+++ b/juju_spell/commands/config.py
@@ -25,7 +25,7 @@ class ApplicationConfig:
 class ConfigCommand(BaseJujuCommand):
     """Command to configure juju applications."""
 
-    async def execute(self, controller: Controller, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+    async def execute(self, controller: Controller, **kwargs: Any) -> Dict[str, Any]:
         """Configure juju applications."""
         output: Dict[str, Any] = {}
         try:

--- a/juju_spell/commands/enable_user.py
+++ b/juju_spell/commands/enable_user.py
@@ -30,7 +30,6 @@ class EnableUserCommand(BaseJujuCommand):
     async def execute(
         self,
         controller: Controller,
-        *args: Any,
         overwrite: bool = False,
         **kwargs: Any,
     ) -> bool:
@@ -59,7 +58,6 @@ class DisableUserCommand(BaseJujuCommand):
     async def execute(
         self,
         controller: Controller,
-        *args: Any,
         overwrite: bool = False,
         user: Optional[str] = None,
         **kwargs: Any,

--- a/juju_spell/commands/grant.py
+++ b/juju_spell/commands/grant.py
@@ -53,7 +53,6 @@ class GrantCommand(BaseJujuCommand):
     async def execute(
         self,
         controller: Controller,
-        *args: Any,
         models: Optional[List[str]] = None,
         overwrite: bool = False,
         **kwargs: Any,

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -13,9 +13,7 @@ from juju_spell.utils import Cache, load_from_cache, save_to_cache
 class ListModelsCommand(BaseJujuCommand):
     """Command to list models from the local cache or from the controllers."""
 
-    async def execute(
-        self, controller: Controller, *args: Any, **kwargs: Any
-    ) -> Dict[str, Union[List, bool]]:
+    async def execute(self, controller: Controller, **kwargs: Any) -> Dict[str, Union[List, bool]]:
         """List models from the local cache or from the controllers."""
         cache: Union[None, Cache] = None
 

--- a/juju_spell/commands/ping.py
+++ b/juju_spell/commands/ping.py
@@ -9,7 +9,7 @@ from juju_spell.commands.base import BaseJujuCommand
 class PingCommand(BaseJujuCommand):
     """Ping command."""
 
-    async def execute(self, controller: Controller, *args: Any, **kwargs: Any) -> str:
+    async def execute(self, controller: Controller, **kwargs: Any) -> str:
         """Check if controller is connected."""
         connected = controller.is_connected()
         self.logger.debug("%s is connected '%r'", controller.controller_uuid, connected)

--- a/juju_spell/commands/remove_user.py
+++ b/juju_spell/commands/remove_user.py
@@ -42,7 +42,6 @@ class RemoveUserCommand(BaseJujuCommand):
     async def execute(
         self,
         controller: Controller,
-        *args: Any,
         models: Optional[List[str]] = None,
         user: Optional[str] = None,
         **kwargs: Any,

--- a/juju_spell/commands/revoke.py
+++ b/juju_spell/commands/revoke.py
@@ -29,7 +29,6 @@ class RevokeCommand(BaseJujuCommand):
     async def execute(
         self,
         controller: Controller,
-        *args: Any,
         user: Optional[str] = None,
         acl: Optional[str] = "login",
         **kwargs: Any,
@@ -45,7 +44,6 @@ class RevokeModelCommand(BaseJujuCommand):
     async def execute(
         self,
         controller: Controller,
-        *args: Any,
         user: Optional[str] = None,
         model_uuid: Optional[str] = None,
         acl: Optional[str] = "read",

--- a/juju_spell/commands/show_controller.py
+++ b/juju_spell/commands/show_controller.py
@@ -10,12 +10,7 @@ from juju_spell.commands.base import BaseJujuCommand
 class ShowControllerCommand(BaseJujuCommand):
     """Command to show a controller."""
 
-    async def execute(
-        self,
-        controller: Controller,
-        *args: Any,
-        **kwargs: Any,
-    ) -> ControllerAPIInfoResults:
+    async def execute(self, controller: Controller, **kwargs: Any) -> ControllerAPIInfoResults:
         """Execute main code.
 
         Changed name because this has to override base_command.

--- a/juju_spell/commands/status.py
+++ b/juju_spell/commands/status.py
@@ -11,7 +11,7 @@ class StatusCommand(BaseJujuCommand):
     """Command to show status for models."""
 
     async def execute(
-        self, controller: Controller, *args: Any, models: Optional[List[str]] = None, **kwargs: Any
+        self, controller: Controller, models: Optional[List[str]] = None, **kwargs: Any
     ) -> Dict[str, FullStatus]:
         """Get status for selected models in controller."""
         output = {}

--- a/juju_spell/commands/update_packages.py
+++ b/juju_spell/commands/update_packages.py
@@ -77,12 +77,7 @@ class Updates:
 class UpdatePackagesCommand(BaseJujuCommand):
     """Update packages command."""
 
-    async def execute(
-        self,
-        controller: Controller,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:  # pragma: no cover
+    async def execute(self, controller: Controller, **kwargs: Any) -> Any:  # pragma: no cover
         """Run update."""
         self.logger.info("Running execute on controller %s", controller.controller_name)
         return await self.make_updates(


### PR DESCRIPTION
There is really no need to use `*args` and execute function and mypy is forcing us to use it everywhere.