### PR TITLE
Add cache policy

### DIFF
--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -1,13 +1,13 @@
 """List models from the local cache or from the controllers."""
 from logging import Logger
 from time import time
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from juju.controller import Controller
 
 from juju_spell.commands.base import BaseJujuCommand
 from juju_spell.exceptions import JujuSpellError
-from juju_spell.utils import Cache, load_from_cache, save_to_cache
+from juju_spell.utils import FileCache
 
 
 class ListModelsCommand(BaseJujuCommand):
@@ -17,13 +17,13 @@ class ListModelsCommand(BaseJujuCommand):
         self, controller: Controller, *args: Any, **kwargs: Any
     ) -> Dict[str, Union[List, bool]]:
         """List models from the local cache or from the controllers."""
-        cache: Union[None, Cache] = None
+        file_cache: Union[None, FileCache] = None
 
         if not kwargs["refresh"]:
             fname = f"{self.name}_{kwargs['controller_config'].uuid}"
-            cache = load_cache_data(fname, self.logger, kwargs["controller_config"].uuid)
+            file_cache = load_cache_data(fname, self.logger, kwargs["controller_config"].uuid)
 
-        if kwargs["refresh"] or cache is None:
+        if kwargs["refresh"] or file_cache is None or file_cache.expired:
             models = list(
                 await self.get_filtered_model_names(
                     controller=controller,
@@ -31,17 +31,21 @@ class ListModelsCommand(BaseJujuCommand):
                     model_mappings=kwargs["controller_config"].model_mapping,
                 )
             )
-            cache = save_cache_data(controller, models, kwargs["refresh"], self.logger, self.name)
+            file_cache = save_cache_data(
+                controller, models, kwargs["refresh"], self.logger, self.name
+            )
 
-        self.logger.debug("%s list models: %s", controller.controller_uuid, cache.data["models"])
-        return cache.context
+        self.logger.debug(
+            "%s list models: %s", controller.controller_uuid, file_cache.data["models"]
+        )
+        return file_cache.context
 
 
 def save_cache_data(
     controller: Controller, models: List[str], refresh: bool, logger: Logger, command_name: str
-) -> Cache:
+) -> FileCache:
     """Gracefully save cache data to default cache directory."""
-    cache = Cache(
+    file_cache = FileCache(
         uuid=controller.controller_uuid,
         name=controller.controller_name,
         data={
@@ -53,23 +57,23 @@ def save_cache_data(
     fname = f"{command_name}_{controller.controller_uuid}"
     error_message_template = "%s list models failed to save cache: %s."
     try:
-        save_to_cache(cache, fname)
+        file_cache.commit(fname)
         logger.debug(
             "%s list models: save result to cache `%s`", controller.controller_uuid, str(fname)
         )
     except JujuSpellError as error:
         logger.warning(error_message_template, controller.controller_uuid, str(error))
-    return cache
+    return file_cache
 
 
-def load_cache_data(fname: str, logger: Logger, uuid: str) -> Union[None, Cache]:
+def load_cache_data(fname: str, logger: Logger, uuid: str) -> Optional[FileCache]:
     """Gracefully load cache data from default cache directory."""
-    cache = None
+    file_cache = None
     error_message_template = "%s list models failed to load cache: %s."
     try:
-        cache = load_from_cache(fname)
-        cache.data["refresh"] = False
+        file_cache = FileCache.connect(fname)
+        file_cache.data["refresh"] = False
         logger.debug("%s list models: load result from cache `%s`", uuid, str(fname))
     except JujuSpellError as error:
         logger.warning(error_message_template, uuid, str(error))
-    return cache
+    return file_cache

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -1,5 +1,4 @@
 """List models from the local cache or from the controllers."""
-from logging import Logger
 from time import time
 from typing import Any, Dict, List, Optional, Union
 
@@ -20,10 +19,9 @@ class ListModelsCommand(BaseJujuCommand):
         file_cache: Union[None, FileCache] = None
 
         if not kwargs["refresh"]:
-            fname = f"{self.name}_{kwargs['controller_config'].uuid}"
-            file_cache = load_cache_data(fname, self.logger, kwargs["controller_config"].uuid)
+            file_cache = self.load_cache_data(controller)
 
-        if kwargs["refresh"] or file_cache is None or file_cache.expired:
+        if kwargs["refresh"] or file_cache is None or file_cache.need_refresh:
             models = list(
                 await self.get_filtered_model_names(
                     controller=controller,
@@ -31,8 +29,12 @@ class ListModelsCommand(BaseJujuCommand):
                     model_mappings=kwargs["controller_config"].model_mapping,
                 )
             )
-            file_cache = save_cache_data(
-                controller, models, kwargs["refresh"], self.logger, self.name
+            file_cache = self.save_cache_data(
+                controller,
+                data={
+                    "models": models,
+                    "refresh": kwargs["refresh"],
+                },
             )
 
         self.logger.debug(
@@ -40,40 +42,38 @@ class ListModelsCommand(BaseJujuCommand):
         )
         return file_cache.context
 
-
-def save_cache_data(
-    controller: Controller, models: List[str], refresh: bool, logger: Logger, command_name: str
-) -> FileCache:
-    """Gracefully save cache data to default cache directory."""
-    file_cache = FileCache(
-        uuid=controller.controller_uuid,
-        name=controller.controller_name,
-        data={
-            "models": models,
-            "refresh": refresh,
-        },
-        timestamp=time(),
-    )
-    fname = f"{command_name}_{controller.controller_uuid}"
-    error_message_template = "%s list models failed to save cache: %s."
-    try:
-        file_cache.commit(fname)
-        logger.debug(
-            "%s list models: save result to cache `%s`", controller.controller_uuid, str(fname)
+    def save_cache_data(self, controller: Controller, data: Dict[str, Any]) -> FileCache:
+        """Gracefully save cache data to default cache directory."""
+        file_cache = FileCache(
+            uuid=controller.controller_uuid,
+            name=controller.controller_name,
+            data=data,
+            timestamp=time(),
         )
-    except JujuSpellError as error:
-        logger.warning(error_message_template, controller.controller_uuid, str(error))
-    return file_cache
+        fname = f"{self.name}_{controller.controller_uuid}"
+        error_message_template = "%s list models failed to save cache: %s."
+        try:
+            file_cache.commit(fname)
+            self.logger.debug(
+                "%s list models: save result to cache `%s`", controller.controller_uuid, str(fname)
+            )
+        except JujuSpellError as error:
+            self.logger.warning(error_message_template, controller.controller_uuid, str(error))
+        return file_cache
 
-
-def load_cache_data(fname: str, logger: Logger, uuid: str) -> Optional[FileCache]:
-    """Gracefully load cache data from default cache directory."""
-    file_cache = None
-    error_message_template = "%s list models failed to load cache: %s."
-    try:
-        file_cache = FileCache.connect(fname)
-        file_cache.data["refresh"] = False
-        logger.debug("%s list models: load result from cache `%s`", uuid, str(fname))
-    except JujuSpellError as error:
-        logger.warning(error_message_template, uuid, str(error))
-    return file_cache
+    def load_cache_data(self, controller: Controller) -> Optional[FileCache]:
+        """Gracefully load cache data from default cache directory."""
+        file_cache = None
+        fname = f"{self.name}_{controller.controller_uuid}"
+        error_message_template = "%s list models failed to load cache: %s."
+        try:
+            file_cache = FileCache.connect(fname)
+            file_cache.data["refresh"] = False
+            self.logger.debug(
+                "%s list models: load result from cache `%s`",
+                controller.controller_uuid,
+                str(fname),
+            )
+        except JujuSpellError as error:
+            self.logger.warning(error_message_template, controller.controller_uuid, str(error))
+        return file_cache

--- a/juju_spell/utils.py
+++ b/juju_spell/utils.py
@@ -99,6 +99,11 @@ class FileCache(Cache, FileCacheContext):
         return self.timestamp + self.policy.ttl < time()
 
     @property
+    def need_refresh(self) -> bool:
+        """Check if the cache needs refresh or not."""
+        return self.expired and self.policy.auto_refresh
+
+    @property
     def context(self) -> Dict[str, Any]:
         """Get the file cache context as a dictionary."""
         return dataclasses.asdict(self)

--- a/juju_spell/utils.py
+++ b/juju_spell/utils.py
@@ -37,32 +37,22 @@ DEFAULT_TTL_RULE = 3600  # in seconds
 DEFAULT_AUTO_REFRESH_RULE = True
 
 
-class BaseCachePolicy(dict):
-    """Base class for cache policy."""
+@dataclasses.dataclass()
+class CachePolicy:
+    """A class for cache policy."""
 
-    def __init__(self, **kwargs: Any):
-        """Initialize cache policy."""
-        super().__init__(**kwargs)
+    ttl: int = DEFAULT_TTL_RULE
+    auto_refresh: bool = DEFAULT_AUTO_REFRESH_RULE
 
     @classmethod
     def init_from_config(cls, cache_config: Any) -> None:
         """Load the policy from a user defined policy config."""
 
 
-class DefaultCachePolicy(BaseCachePolicy):
-    """A default cache policy used by any cache data."""
-
-    def __init__(self, ttl: float, auto_refresh: bool = True):
-        """Initialize default cache policy."""
-        super().__init__(ttl=ttl, auto_refresh=auto_refresh)
-
-
 class Cache(metaclass=ABCMeta):
     """A cache for command's output with cache policy."""
 
-    policy: DefaultCachePolicy = DefaultCachePolicy(
-        ttl=DEFAULT_TTL_RULE, auto_refresh=DEFAULT_AUTO_REFRESH_RULE
-    )
+    policy: CachePolicy = CachePolicy()
 
     @property
     @abstractmethod
@@ -106,7 +96,7 @@ class FileCache(Cache, FileCacheContext):
     @property
     def expired(self) -> bool:
         """Check if the cache is expired or not."""
-        return self.timestamp + self.policy["ttl"] < time()
+        return self.timestamp + self.policy.ttl < time()
 
     @property
     def context(self) -> Dict[str, Any]:

--- a/juju_spell/utils.py
+++ b/juju_spell/utils.py
@@ -82,7 +82,7 @@ class Cache(metaclass=ABCMeta):
         """Connect to the cache backend, need to implement by the subclass."""
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass()
 class FileCacheContext:
     """A context for holding file cache data."""
 

--- a/juju_spell/utils.py
+++ b/juju_spell/utils.py
@@ -120,12 +120,11 @@ class FileCache(Cache, FileCacheContext):
         """Commit file cache to the default cache directory named by `name`."""
         if not self.cache_directory.exists():
             self.cache_directory.mkdir()
-        if self.cache_name == "" and name == "":
+        self.cache_name = name or self.cache_name
+        if self.cache_name == "":
             raise JujuSpellError(
                 "failed to write commit file cache: missing 'name' for file cache."
             )
-        if name:
-            self.cache_name = name
         fname = self.cache_directory / self.cache_name
         try:
             with open(fname, "w", encoding="UTF-8") as file:

--- a/juju_spell/utils.py
+++ b/juju_spell/utils.py
@@ -33,8 +33,11 @@ from juju_spell.settings import DEFAULT_CACHE_DIR
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TTL_RULE = 3600  # in seconds
+DEFAULT_AUTO_REFRESH_RULE = True
 
-class CachePolicy(dict):
+
+class BaseCachePolicy(dict):
     """Base class for cache policy."""
 
     def __init__(self, **kwargs: Any):
@@ -46,7 +49,7 @@ class CachePolicy(dict):
         """Load the policy from a user defined policy config."""
 
 
-class DefaultCachePolicy(CachePolicy):
+class DefaultCachePolicy(BaseCachePolicy):
     """A default cache policy used by any cache data."""
 
     def __init__(self, ttl: float, auto_refresh: bool = True):
@@ -57,7 +60,9 @@ class DefaultCachePolicy(CachePolicy):
 class Cache(metaclass=ABCMeta):
     """A cache for command's output with cache policy."""
 
-    policy: DefaultCachePolicy = DefaultCachePolicy(ttl=3600, auto_refresh=True)
+    policy: DefaultCachePolicy = DefaultCachePolicy(
+        ttl=DEFAULT_TTL_RULE, auto_refresh=DEFAULT_AUTO_REFRESH_RULE
+    )
 
     @property
     @abstractmethod
@@ -73,7 +78,7 @@ class Cache(metaclass=ABCMeta):
         """Update the cache's data, need to implement by the subclass."""
 
     @abstractmethod
-    def commit(self) -> Any:
+    def commit(self) -> None:
         """Commit the changes to the cache, need to implement by the subclass."""
 
     @classmethod
@@ -88,7 +93,7 @@ class FileCacheContext:
 
     uuid: str = ""
     name: str = ""
-    data: Dict[str, Any] = dataclasses.field(default_factory=lambda: {})
+    data: Dict[str, Any] = dataclasses.field(default_factory=dict)
     timestamp: float = time()
 
 

--- a/tests/unit/commands/test_list_models.py
+++ b/tests/unit/commands/test_list_models.py
@@ -2,15 +2,15 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+import juju_spell.commands.list_models
 from juju_spell.commands import list_models
 from juju_spell.commands.list_models import ListModelsCommand
 from juju_spell.exceptions import JujuSpellError
 
 
 @pytest.mark.asyncio
-@patch("juju_spell.commands.list_models.save_to_cache")
-@patch("juju_spell.commands.list_models.load_from_cache")
-async def test_execute_with_refresh(mock_load_from_cache, mock_save_to_cache):
+@patch.object(juju_spell.commands.list_models.FileCache, "commit")
+async def test_execute_with_refresh(mock_commit):
     """Test execute function for ListModelsCommand with --refresh."""
     mock_controller = AsyncMock()
     mock_controller_config = Mock()
@@ -23,22 +23,23 @@ async def test_execute_with_refresh(mock_load_from_cache, mock_save_to_cache):
         models=None,
     )
 
-    mock_save_to_cache.assert_called_once()
-    mock_load_from_cache.assert_not_called()
+    mock_commit.assert_called_once()
     mock_controller.list_models.assert_awaited_once()
     assert context["data"]["refresh"] is True
 
 
 @pytest.mark.asyncio
-@patch("juju_spell.commands.list_models.save_to_cache")
-@patch("juju_spell.commands.list_models.load_from_cache")
-async def test_11_execute_without_refresh_no_cache(mock_load_from_cache, mock_save_to_cache):
-    """Test execute function for ListModelsCommand without --refresh and no existing cache."""
+@patch.object(juju_spell.commands.list_models.FileCache, "connect")
+async def test_10_execute_without_refresh_has_cache(mock_connect):
+    """Test execute function for ListModelsCommand without --refresh and have existing cache."""
     mock_controller = AsyncMock()
     mock_controller_config = Mock()
     list_models = ListModelsCommand()
 
-    mock_load_from_cache.side_effect = JujuSpellError()
+    mock_cache = Mock()
+    mock_cache.data = {"models": []}
+    mock_cache.expired = False
+    mock_connect.return_value = mock_cache
 
     await list_models.execute(
         controller=mock_controller,
@@ -47,13 +48,61 @@ async def test_11_execute_without_refresh_no_cache(mock_load_from_cache, mock_sa
         models=None,
     )
 
-    mock_save_to_cache.assert_called_once()
-    mock_load_from_cache.assert_called_once()
+    mock_connect.assert_called_once()
+    mock_controller.list_models.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch.object(juju_spell.commands.list_models.FileCache, "commit")
+@patch.object(juju_spell.commands.list_models.FileCache, "connect")
+async def test_11_execute_without_refresh_no_cache(mock_connect, mock_commit):
+    """Test execute function for ListModelsCommand without --refresh and no existing cache."""
+    mock_controller = AsyncMock()
+    mock_controller_config = Mock()
+    list_models = ListModelsCommand()
+
+    mock_connect.side_effect = JujuSpellError()
+
+    await list_models.execute(
+        controller=mock_controller,
+        refresh=False,
+        controller_config=mock_controller_config,
+        models=None,
+    )
+
+    mock_commit.assert_called_once()
+    mock_connect.assert_called_once()
     mock_controller.list_models.assert_awaited_once()
 
 
-@patch("juju_spell.commands.list_models.save_to_cache")
-def test_20_save_cache_data_okay(mock_save_to_cache):
+@pytest.mark.asyncio
+@patch.object(juju_spell.commands.list_models.FileCache, "commit")
+@patch.object(juju_spell.commands.list_models.FileCache, "connect")
+async def test_12_execute_without_refresh_expired_cache(mock_connect, mock_commit):
+    """Test execute function for ListModelsCommand without --refresh and have expired cache."""
+    mock_controller = AsyncMock()
+    mock_controller_config = Mock()
+    list_models = ListModelsCommand()
+
+    mock_cache = Mock()
+    mock_cache.data = {"models": []}
+    mock_cache.expired = True
+    mock_connect.return_value = mock_cache
+
+    await list_models.execute(
+        controller=mock_controller,
+        refresh=False,
+        controller_config=mock_controller_config,
+        models=None,
+    )
+
+    mock_commit.assert_called_once()
+    mock_connect.assert_called_once()
+    mock_controller.list_models.assert_awaited_once()
+
+
+@patch.object(juju_spell.commands.list_models.FileCache, "commit")
+def test_20_save_cache_data_okay(mock_commit):
     """Test save_cache_data function when save cache is okay."""
     mock_models = Mock()
     mock_logger = Mock()
@@ -62,25 +111,25 @@ def test_20_save_cache_data_okay(mock_save_to_cache):
 
     mock_logger.debug.assert_called_once()
     mock_logger.warning.assert_not_called()
-    mock_save_to_cache.assert_called_once()
+    mock_commit.assert_called_once()
 
 
-@patch("juju_spell.commands.list_models.save_to_cache")
-def test_21_save_cache_data_fail(mock_save_to_cache):
+@patch.object(juju_spell.commands.list_models.FileCache, "commit")
+def test_21_save_cache_data_fail(mock_commit):
     """Test save_cache_data function when save cache is not okay."""
     mock_models = Mock()
     mock_logger = Mock()
 
-    mock_save_to_cache.side_effect = JujuSpellError()
+    mock_commit.side_effect = JujuSpellError()
     list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger, Mock())
 
     mock_logger.debug.assert_not_called()
     mock_logger.warning.assert_called_once()
-    mock_save_to_cache.assert_called_once()
+    mock_commit.assert_called_once()
 
 
-@patch("juju_spell.commands.list_models.load_from_cache")
-def test_30_load_cache_data_okay(mock_load_from_cache):
+@patch.object(juju_spell.commands.list_models.FileCache, "connect")
+def test_30_load_cache_data_okay(mock_connect):
     """Test load_cache_data function when load cache is okay."""
     mock_uuid = Mock()
     mock_name = Mock()
@@ -90,19 +139,19 @@ def test_30_load_cache_data_okay(mock_load_from_cache):
 
     mock_logger.debug.assert_called_once()
     mock_logger.warning.assert_not_called()
-    mock_load_from_cache.assert_called_once()
+    mock_connect.assert_called_once()
 
 
-@patch("juju_spell.commands.list_models.load_from_cache")
-def test_31_load_cache_data_fail(mock_load_from_cache):
+@patch.object(juju_spell.commands.list_models.FileCache, "connect")
+def test_31_load_cache_data_fail(mock_connect):
     """Test load_cache_data function when load cache is not okay."""
     mock_uuid = Mock()
     mock_name = Mock()
     mock_logger = Mock()
 
-    mock_load_from_cache.side_effect = JujuSpellError()
+    mock_connect.side_effect = JujuSpellError()
     list_models.load_cache_data(mock_name, mock_logger, mock_uuid)
 
     mock_logger.debug.assert_not_called()
     mock_logger.warning.assert_called_once()
-    mock_load_from_cache.assert_called_once()
+    mock_connect.assert_called_once()

--- a/tests/unit/commands/test_list_models.py
+++ b/tests/unit/commands/test_list_models.py
@@ -148,6 +148,11 @@ async def test_30_load_cache_data_okay(mock_connect):
     mock_controller_config = Mock()
     list_models = ListModelsCommand()
 
+    mock_cache = Mock()
+    mock_cache.data = {"models": []}
+    mock_cache.need_refresh = False
+    mock_connect.return_value = mock_cache
+
     await list_models.execute(
         controller=mock_controller,
         refresh=False,
@@ -159,21 +164,28 @@ async def test_30_load_cache_data_okay(mock_connect):
 
 
 @pytest.mark.asyncio
+@patch.object(juju_spell.commands.list_models.FileCache, "commit")
 @patch.object(juju_spell.commands.list_models.FileCache, "connect")
-async def test_31_load_cache_data_fail(mock_connect):
+async def test_31_load_cache_data_fail(mock_connect, mock_commit):
     """Test load_cache_data function when load cache is not okay."""
     mock_controller = AsyncMock()
     mock_controller_config = Mock()
     list_models = ListModelsCommand()
     list_models.logger = Mock()
 
+    mock_cache = Mock()
+    mock_cache.data = {"models": []}
+    mock_cache.need_refresh = False
+    mock_connect.return_value = mock_cache
+
     mock_connect.side_effect = JujuSpellError()
 
     await list_models.execute(
         controller=mock_controller,
-        refresh=True,
+        refresh=False,
         controller_config=mock_controller_config,
         models=None,
     )
 
+    mock_commit.assert_called_once()
     list_models.logger.warning.assert_called_once()


### PR DESCRIPTION
This PR extends the caching logic and defines a cache policy that can be used by any cache object. It's a conceptual implementation. Currently, we have a `FileCache` with a default cache policy `DefaultCachePolicy` that will check if the cache is expired or not, based on the default cache policy. So the cache logic is extended:

- When run as `juju-spell list-models`
   - **[new]** If cached result exist but the cache is expired (based on the cache policy), it will fetch result from the controller and then save the result to the cache directory.

