### PR TITLE
Create generic caching mechanism

### DIFF
--- a/juju_spell/cache.py
+++ b/juju_spell/cache.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TTL_RULE = 3600  # in seconds
 DEFAULT_CACHE_BACKEND = "FileCache"
-AVALIABLE_BACKENDS = {"FileCache"}
+AVALIABLE_BACKENDS = {DEFAULT_CACHE_BACKEND}
 
 
 def use_cache(backend: str = DEFAULT_CACHE_BACKEND) -> "Cache":

--- a/juju_spell/cache.py
+++ b/juju_spell/cache.py
@@ -1,0 +1,141 @@
+# -*- Mode:Python; indent-tabs-mode:nil; tab-width:4 -*-
+#
+# Copyright 2021-2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Data structures to offer caching cache to juju-spell."""
+from __future__ import annotations
+
+import dataclasses
+import logging
+from abc import ABCMeta, abstractmethod
+from pathlib import Path
+from time import time
+from typing import Any, Dict, Optional
+
+import yaml
+
+from juju_spell.exceptions import JujuSpellError
+from juju_spell.settings import DEFAULT_CACHE_DIR
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_RULE = 3600  # in seconds
+DEFAULT_CACHE_BACKEND = "FileCache"
+AVALIABLE_BACKENDS = {"FileCache"}
+
+
+def use_cache(backend: str = DEFAULT_CACHE_BACKEND) -> "Cache":
+    """Get the cache class based on the caching backend."""
+    if backend not in AVALIABLE_BACKENDS:
+        raise JujuSpellError(f"Supported cache backends are {AVALIABLE_BACKENDS}")
+    return FileCache()
+
+
+@dataclasses.dataclass
+class CachePolicy:
+    """A class for cache policy."""
+
+    ttl: int = DEFAULT_TTL_RULE
+
+
+class Cache(metaclass=ABCMeta):
+    """A cache for command's output with cache policy."""
+
+    policy: CachePolicy = CachePolicy()
+    cache_directory: Path = DEFAULT_CACHE_DIR
+
+    def __init__(self) -> None:
+        """Initialize the cache."""
+        if not self.cache_directory.exists():
+            self.cache_directory.mkdir()
+
+    @abstractmethod
+    def get(self, key: str) -> Any:
+        """Get data from the cache, need to implement by the subclass."""
+
+    @abstractmethod
+    def put(self, key: str, value: Any) -> None:
+        """Update the cache's data, need to implement by the subclass."""
+
+
+@dataclasses.dataclass
+class FileCacheContext:
+    """A context for holding output from each command."""
+
+    timestamp: float = time()
+    data: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+class FileCache(Cache):
+    """Create a cache file to store the data."""
+
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        """Get the data from the file cache."""
+        context = self._connect(key)
+        if not context:
+            return None
+        return dataclasses.asdict(context)
+
+    def put(self, key: str, value: Dict[str, Any]) -> None:
+        """Add or update the data in the file cache."""
+        self._commit(key, FileCacheContext(timestamp=time(), data=value))
+
+    def delete(self, key: str) -> None:
+        """Delete the data from the file cache."""
+        self._remove(key)
+
+    def check_expired(self, key: str) -> bool:
+        """Check if the cache is expired or not."""
+        context = self._connect(key)
+        if not context:
+            return True
+        return context.timestamp + self.policy.ttl < time()
+
+    def _commit(self, key: str, context: FileCacheContext) -> None:
+        """Commit the changes to the disk."""
+        cache_name = self.cache_directory / key
+        try:
+            with open(cache_name, "w", encoding="UTF-8") as file:
+                data = yaml.safe_dump(dataclasses.asdict(context))
+                file.write(data)
+        except PermissionError as error:
+            raise JujuSpellError(f"permission denied to write to file `{cache_name}`.") from error
+        except Exception as error:
+            raise JujuSpellError(f"{str(error)}.") from error
+
+    def _connect(self, key: str) -> Optional[FileCacheContext]:
+        """Connect to file cache or create a new file cache."""
+        cache_name = self.cache_directory / key
+        try:
+            if not cache_name.exists():
+                return None
+            with open(cache_name, "r", encoding="UTF-8") as file:
+                return FileCacheContext(**yaml.safe_load(file))
+        except PermissionError as error:
+            raise JujuSpellError(f"permission denied to read from file `{cache_name}`.") from error
+        except Exception as error:
+            raise JujuSpellError(f"{str(error)}.") from error
+
+    def _remove(self, key: str) -> None:
+        """Remove the data from the file cache."""
+        cache_name = self.cache_directory / key
+        try:
+            cache_name.unlink()
+        except FileNotFoundError as error:
+            raise JujuSpellError(f"`{cache_name}` does not exists.") from error
+        except PermissionError as error:
+            raise JujuSpellError(f"permission denied to read from file `{cache_name}`.") from error
+        except Exception as error:
+            raise JujuSpellError(f"{str(error)}.") from error

--- a/juju_spell/cache.py
+++ b/juju_spell/cache.py
@@ -63,11 +63,15 @@ class Cache(metaclass=ABCMeta):
 
     @abstractmethod
     def get(self, key: str) -> Any:
-        """Get data from the cache, need to implement by the subclass."""
+        """Get the data from the cache."""
 
     @abstractmethod
     def put(self, key: str, value: Any) -> None:
-        """Update the cache's data, need to implement by the subclass."""
+        """Add or update the data in the cache."""
+
+    @abstractmethod
+    def delete(self, key: str) -> None:
+        """Delete the data from the cache."""
 
 
 @dataclasses.dataclass

--- a/juju_spell/cache.py
+++ b/juju_spell/cache.py
@@ -140,6 +140,6 @@ class FileCache(Cache):
         except FileNotFoundError as error:
             raise JujuSpellError(f"`{cache_name}` does not exists.") from error
         except PermissionError as error:
-            raise JujuSpellError(f"permission denied to read from file `{cache_name}`.") from error
+            raise JujuSpellError(f"permission denied to delete file `{cache_name}`.") from error
         except Exception as error:
             raise JujuSpellError(f"{str(error)}.") from error

--- a/juju_spell/cache.py
+++ b/juju_spell/cache.py
@@ -73,6 +73,12 @@ class Cache(metaclass=ABCMeta):
     def delete(self, key: str) -> None:
         """Delete the data from the cache."""
 
+    def check_expired(self, key: str) -> bool:
+        """Check if the cache is expired or not; should be implemented if necessary."""
+        raise NotImplementedError(
+            "Subclasses of `Cache` should implement this method if necessary."
+        )
+
 
 @dataclasses.dataclass
 class FileCacheContext:

--- a/juju_spell/cli/list_models.py
+++ b/juju_spell/cli/list_models.py
@@ -98,8 +98,6 @@ class ListModelsCMD(JujuReadCMD):
                 },
                 "success": true,
                 "output": {
-                    "uuid": "03ascsb2-bba8-477b-854e-5715a7sb320a",
-                    "name": "xxx-serverstack",
                     "data": {
                         "models": [
                             "controller",
@@ -122,9 +120,10 @@ class ListModelsCMD(JujuReadCMD):
         heading = ""
         for content in retval:
             output = content["output"]
-            controller_name = output["name"]
             models = output["data"]["models"]
             refresh = output["data"]["refresh"]
+            context = content["context"]
+            controller_name = context["name"]
             controller_models_mapping[controller_name] = models
             if not refresh:
                 timestamp = float(output["timestamp"])

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -25,7 +25,7 @@ class ListModelsCommand(BaseJujuCommand):
                 context["data"]["refresh"] = False
                 models = context["data"]["models"]
 
-        if kwargs["refresh"] or context is None or cache.check_expired(list_models_key):
+        if kwargs["refresh"] or context is None:
             models = list(
                 await self.get_filtered_model_names(
                     controller=controller,

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -1,13 +1,10 @@
 """List models from the local cache or from the controllers."""
-from logging import Logger
-from time import time
 from typing import Any, Dict, List, Union
 
 from juju.controller import Controller
 
+from juju_spell.cache import DEFAULT_CACHE_BACKEND, use_cache
 from juju_spell.commands.base import BaseJujuCommand
-from juju_spell.exceptions import JujuSpellError
-from juju_spell.utils import Cache, load_from_cache, save_to_cache
 
 
 class ListModelsCommand(BaseJujuCommand):
@@ -17,13 +14,18 @@ class ListModelsCommand(BaseJujuCommand):
         self, controller: Controller, *args: Any, **kwargs: Any
     ) -> Dict[str, Union[List, bool]]:
         """List models from the local cache or from the controllers."""
-        cache: Union[None, Cache] = None
+        cache: Any = use_cache(DEFAULT_CACHE_BACKEND)
+        list_models_key = f"{self.name}_{controller.controller_uuid}"
+        context = None
+        models = []
 
         if not kwargs["refresh"]:
-            fname = f"{self.name}_{kwargs['controller_config'].uuid}"
-            cache = load_cache_data(fname, self.logger, kwargs["controller_config"].uuid)
+            context = cache.get(list_models_key)
+            if context:
+                context["data"]["refresh"] = kwargs["refresh"]
+                models = context["data"]["models"]
 
-        if kwargs["refresh"] or cache is None:
+        if kwargs["refresh"] or context is None or cache.check_expired(list_models_key):
             models = list(
                 await self.get_filtered_model_names(
                     controller=controller,
@@ -31,45 +33,8 @@ class ListModelsCommand(BaseJujuCommand):
                     model_mappings=kwargs["controller_config"].model_mapping,
                 )
             )
-            cache = save_cache_data(controller, models, kwargs["refresh"], self.logger, self.name)
+            cache.put(list_models_key, {"models": models, "refresh": kwargs["refresh"]})
+            context = cache.get(list_models_key)
 
-        self.logger.debug("%s list models: %s", controller.controller_uuid, cache.data["models"])
-        return cache.context
-
-
-def save_cache_data(
-    controller: Controller, models: List[str], refresh: bool, logger: Logger, command_name: str
-) -> Cache:
-    """Gracefully save cache data to default cache directory."""
-    cache = Cache(
-        uuid=controller.controller_uuid,
-        name=controller.controller_name,
-        data={
-            "models": models,
-            "refresh": refresh,
-        },
-        timestamp=time(),
-    )
-    fname = f"{command_name}_{controller.controller_uuid}"
-    error_message_template = "%s list models failed to save cache: %s."
-    try:
-        save_to_cache(cache, fname)
-        logger.debug(
-            "%s list models: save result to cache `%s`", controller.controller_uuid, str(fname)
-        )
-    except JujuSpellError as error:
-        logger.warning(error_message_template, controller.controller_uuid, str(error))
-    return cache
-
-
-def load_cache_data(fname: str, logger: Logger, uuid: str) -> Union[None, Cache]:
-    """Gracefully load cache data from default cache directory."""
-    cache = None
-    error_message_template = "%s list models failed to load cache: %s."
-    try:
-        cache = load_from_cache(fname)
-        cache.data["refresh"] = False
-        logger.debug("%s list models: load result from cache `%s`", uuid, str(fname))
-    except JujuSpellError as error:
-        logger.warning(error_message_template, uuid, str(error))
-    return cache
+        self.logger.debug("%s list models: %s", controller.controller_uuid, models)
+        return context

--- a/juju_spell/commands/list_models.py
+++ b/juju_spell/commands/list_models.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Union
 
 from juju.controller import Controller
 
-from juju_spell.cache import DEFAULT_CACHE_BACKEND, use_cache
+from juju_spell.cache import DEFAULT_CACHE_BACKEND, Cache, use_cache
 from juju_spell.commands.base import BaseJujuCommand
 
 
@@ -14,7 +14,7 @@ class ListModelsCommand(BaseJujuCommand):
         self, controller: Controller, *args: Any, **kwargs: Any
     ) -> Dict[str, Union[List, bool]]:
         """List models from the local cache or from the controllers."""
-        cache: Any = use_cache(DEFAULT_CACHE_BACKEND)
+        cache: Cache = use_cache(DEFAULT_CACHE_BACKEND)
         list_models_key = f"{self.name}_{controller.controller_uuid}"
         context = None
         models = []
@@ -22,7 +22,7 @@ class ListModelsCommand(BaseJujuCommand):
         if not kwargs["refresh"]:
             context = cache.get(list_models_key)
             if context:
-                context["data"]["refresh"] = kwargs["refresh"]
+                context["data"]["refresh"] = False
                 models = context["data"]["models"]
 
         if kwargs["refresh"] or context is None or cache.check_expired(list_models_key):
@@ -33,7 +33,7 @@ class ListModelsCommand(BaseJujuCommand):
                     model_mappings=kwargs["controller_config"].model_mapping,
                 )
             )
-            cache.put(list_models_key, {"models": models, "refresh": kwargs["refresh"]})
+            cache.put(list_models_key, {"models": models, "refresh": True})
             context = cache.get(list_models_key)
 
         self.logger.debug("%s list models: %s", controller.controller_uuid, models)

--- a/tests/unit/commands/test_list_models.py
+++ b/tests/unit/commands/test_list_models.py
@@ -33,7 +33,6 @@ async def test_10_execute_without_refresh_has_cache(mock_use_cache):
 
     mock_cache = Mock()
     mock_cache.get.return_value = {"data": {"refresh": False, "models": []}}
-    mock_cache.check_expired.return_value = False
     mock_use_cache.return_value = mock_cache
 
     await list_models.execute(
@@ -57,30 +56,6 @@ async def test_11_execute_without_refresh_no_cache(mock_use_cache):
 
     mock_cache = Mock()
     mock_cache.get.return_value = None
-    mock_cache.check_expired.return_value = False
-    mock_use_cache.return_value = mock_cache
-
-    await list_models.execute(
-        controller=mock_controller,
-        refresh=False,
-        controller_config=mock_controller_config,
-        models=None,
-    )
-
-    mock_controller.list_models.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-@patch("juju_spell.commands.list_models.use_cache")
-async def test_12_execute_without_refresh_expired_cache(mock_use_cache):
-    """Test execute function for ListModelsCommand without --refresh and have expired cache."""
-    mock_controller = AsyncMock()
-    mock_controller_config = Mock()
-    list_models = ListModelsCommand()
-
-    mock_cache = Mock()
-    mock_cache.get.return_value = {"data": {"refresh": False, "models": []}}
-    mock_cache.check_expired.return_value = True
     mock_use_cache.return_value = mock_cache
 
     await list_models.execute(

--- a/tests/unit/commands/test_list_models.py
+++ b/tests/unit/commands/test_list_models.py
@@ -2,43 +2,39 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from juju_spell.commands import list_models
 from juju_spell.commands.list_models import ListModelsCommand
-from juju_spell.exceptions import JujuSpellError
 
 
 @pytest.mark.asyncio
-@patch("juju_spell.commands.list_models.save_to_cache")
-@patch("juju_spell.commands.list_models.load_from_cache")
-async def test_execute_with_refresh(mock_load_from_cache, mock_save_to_cache):
+@patch("juju_spell.commands.list_models.use_cache")
+async def test_execute_with_refresh(mock_use_cache):
     """Test execute function for ListModelsCommand with --refresh."""
     mock_controller = AsyncMock()
     mock_controller_config = Mock()
     list_models = ListModelsCommand()
 
-    context = await list_models.execute(
+    await list_models.execute(
         controller=mock_controller,
         refresh=True,
         controller_config=mock_controller_config,
         models=None,
     )
 
-    mock_save_to_cache.assert_called_once()
-    mock_load_from_cache.assert_not_called()
     mock_controller.list_models.assert_awaited_once()
-    assert context["data"]["refresh"] is True
 
 
 @pytest.mark.asyncio
-@patch("juju_spell.commands.list_models.save_to_cache")
-@patch("juju_spell.commands.list_models.load_from_cache")
-async def test_11_execute_without_refresh_no_cache(mock_load_from_cache, mock_save_to_cache):
-    """Test execute function for ListModelsCommand without --refresh and no existing cache."""
+@patch("juju_spell.commands.list_models.use_cache")
+async def test_10_execute_without_refresh_has_cache(mock_use_cache):
+    """Test execute function for ListModelsCommand without --refresh and have existing cache."""
     mock_controller = AsyncMock()
     mock_controller_config = Mock()
     list_models = ListModelsCommand()
 
-    mock_load_from_cache.side_effect = JujuSpellError()
+    mock_cache = Mock()
+    mock_cache.get.return_value = {"data": {"refresh": False, "models": []}}
+    mock_cache.check_expired.return_value = False
+    mock_use_cache.return_value = mock_cache
 
     await list_models.execute(
         controller=mock_controller,
@@ -47,62 +43,51 @@ async def test_11_execute_without_refresh_no_cache(mock_load_from_cache, mock_sa
         models=None,
     )
 
-    mock_save_to_cache.assert_called_once()
-    mock_load_from_cache.assert_called_once()
+    mock_controller.list_models.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("juju_spell.commands.list_models.use_cache")
+async def test_11_execute_without_refresh_no_cache(mock_use_cache):
+    """Test execute function for ListModelsCommand without --refresh and no existing cache."""
+    mock_controller = AsyncMock()
+    mock_controller_config = Mock()
+    list_models = ListModelsCommand()
+    list_models.logger.debug = Mock()
+
+    mock_cache = Mock()
+    mock_cache.get.return_value = None
+    mock_cache.check_expired.return_value = False
+    mock_use_cache.return_value = mock_cache
+
+    await list_models.execute(
+        controller=mock_controller,
+        refresh=False,
+        controller_config=mock_controller_config,
+        models=None,
+    )
+
     mock_controller.list_models.assert_awaited_once()
 
 
-@patch("juju_spell.commands.list_models.save_to_cache")
-def test_20_save_cache_data_okay(mock_save_to_cache):
-    """Test save_cache_data function when save cache is okay."""
-    mock_models = Mock()
-    mock_logger = Mock()
+@pytest.mark.asyncio
+@patch("juju_spell.commands.list_models.use_cache")
+async def test_12_execute_without_refresh_expired_cache(mock_use_cache):
+    """Test execute function for ListModelsCommand without --refresh and have expired cache."""
+    mock_controller = AsyncMock()
+    mock_controller_config = Mock()
+    list_models = ListModelsCommand()
 
-    list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger, Mock())
+    mock_cache = Mock()
+    mock_cache.get.return_value = {"data": {"refresh": False, "models": []}}
+    mock_cache.check_expired.return_value = True
+    mock_use_cache.return_value = mock_cache
 
-    mock_logger.debug.assert_called_once()
-    mock_logger.warning.assert_not_called()
-    mock_save_to_cache.assert_called_once()
+    await list_models.execute(
+        controller=mock_controller,
+        refresh=False,
+        controller_config=mock_controller_config,
+        models=None,
+    )
 
-
-@patch("juju_spell.commands.list_models.save_to_cache")
-def test_21_save_cache_data_fail(mock_save_to_cache):
-    """Test save_cache_data function when save cache is not okay."""
-    mock_models = Mock()
-    mock_logger = Mock()
-
-    mock_save_to_cache.side_effect = JujuSpellError()
-    list_models.save_cache_data(Mock(), mock_models, Mock(), mock_logger, Mock())
-
-    mock_logger.debug.assert_not_called()
-    mock_logger.warning.assert_called_once()
-    mock_save_to_cache.assert_called_once()
-
-
-@patch("juju_spell.commands.list_models.load_from_cache")
-def test_30_load_cache_data_okay(mock_load_from_cache):
-    """Test load_cache_data function when load cache is okay."""
-    mock_uuid = Mock()
-    mock_name = Mock()
-    mock_logger = Mock()
-
-    list_models.load_cache_data(mock_name, mock_logger, mock_uuid)
-
-    mock_logger.debug.assert_called_once()
-    mock_logger.warning.assert_not_called()
-    mock_load_from_cache.assert_called_once()
-
-
-@patch("juju_spell.commands.list_models.load_from_cache")
-def test_31_load_cache_data_fail(mock_load_from_cache):
-    """Test load_cache_data function when load cache is not okay."""
-    mock_uuid = Mock()
-    mock_name = Mock()
-    mock_logger = Mock()
-
-    mock_load_from_cache.side_effect = JujuSpellError()
-    list_models.load_cache_data(mock_name, mock_logger, mock_uuid)
-
-    mock_logger.debug.assert_not_called()
-    mock_logger.warning.assert_called_once()
-    mock_load_from_cache.assert_called_once()
+    mock_controller.list_models.assert_awaited_once()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,140 @@
+import shutil
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+
+import juju_spell
+from juju_spell.cache import AVALIABLE_BACKENDS, DEFAULT_CACHE_BACKEND, Cache, use_cache
+from juju_spell.exceptions import JujuSpellError
+
+
+@pytest.fixture(scope="session")
+def tmp_cache_dir():
+    # don't use tempfile / tmp_path_dir to increase test coverage
+    tmp_cache_dir = Path("/tmp/test-cache")
+    Cache.cache_directory = tmp_cache_dir
+    yield tmp_cache_dir
+    shutil.rmtree(tmp_cache_dir)
+
+
+def test_00_file_cache_normal(tmp_cache_dir):
+    """Test file cache class under normal situation."""
+    file_cache = use_cache(DEFAULT_CACHE_BACKEND)
+    file_cache.cache_directory = tmp_cache_dir
+
+    # test put
+    key1 = "key1"
+    value1 = {"name": "foo"}
+    file_cache.put(key1, value1)
+    cache_file1 = tmp_cache_dir / key1
+    assert cache_file1.exists()
+
+    # test get
+    data = file_cache.get(key1)["data"]
+    timestamp = file_cache.get(key1)["timestamp"]
+    assert data == value1
+    assert timestamp
+
+    # test delete
+    file_cache.delete(key1)
+    assert not cache_file1.exists()
+
+
+@patch.object(juju_spell.cache.FileCache, "_check_expired")
+def test_01_file_cache_get(mock_check_expired, tmp_cache_dir):
+    """Test file cache get method."""
+    file_cache = use_cache(DEFAULT_CACHE_BACKEND)
+    file_cache.cache_directory = tmp_cache_dir
+
+    # create some data
+    key = "key"
+    value = {"name": "foo"}
+    file_cache.put(key, value)
+    cache_file = tmp_cache_dir / key
+    assert cache_file.exists()
+
+    # test get: expire cache
+    data = file_cache.get(key)
+    assert not data
+    assert not cache_file.exists()
+
+    # test get: no key
+    data = file_cache.get("random_key")
+    assert not data
+
+    # test get: permission denied
+    file_cache.put(key, value)
+    with patch("builtins.open", new_callable=mock_open) as fake_open:
+        fake_open.side_effect = PermissionError()
+        with pytest.raises(JujuSpellError, match="permission denied to read from file "):
+            file_cache.get(key)
+
+    # test get: general error
+    with patch("builtins.open", new_callable=mock_open) as fake_open:
+        fake_open.side_effect = Exception()
+        with pytest.raises(JujuSpellError):
+            file_cache.get(key)
+
+
+def test_02_file_cache_put(tmp_cache_dir):
+    """Test file cache put method."""
+    file_cache = use_cache(DEFAULT_CACHE_BACKEND)
+    file_cache.cache_directory = tmp_cache_dir
+
+    # test put: normal
+    key = "key"
+    value = {"name": "foo"}
+    file_cache.put(key, value)
+    cache_file = tmp_cache_dir / key
+    assert cache_file.exists()
+
+    # test put: permission denied
+    with patch("builtins.open", new_callable=mock_open) as fake_open:
+        fake_open.side_effect = PermissionError()
+        with pytest.raises(JujuSpellError, match="permission denied to write to file"):
+            file_cache.put(key, value)
+
+    # test put: general error
+    with patch("builtins.open", new_callable=mock_open) as fake_open:
+        fake_open.side_effect = Exception()
+        with pytest.raises(JujuSpellError):
+            file_cache.put(key, value)
+
+
+def test_03_file_cache_delete(tmp_cache_dir):
+    """Test file cache delete method."""
+    file_cache = use_cache(DEFAULT_CACHE_BACKEND)
+    file_cache.cache_directory = tmp_cache_dir
+
+    # create some data
+    key = "key"
+    value = {"name": "foo"}
+    file_cache.put(key, value)
+    cache_file = tmp_cache_dir / key
+    assert cache_file.exists()
+
+    # test delete: normal
+    file_cache.delete(key)
+    assert not cache_file.exists()
+
+    # test delete: not found error
+    with pytest.raises(JujuSpellError, match="does not exists."):
+        file_cache.delete("non-existing-key")
+    # test put: permission denied
+    with patch("pathlib.Path.unlink") as mock_unlink:
+        mock_unlink.side_effect = PermissionError()
+        with pytest.raises(JujuSpellError, match="permission denied to delete file"):
+            file_cache.delete(key)
+
+    # test put: general error
+    with patch("pathlib.Path.unlink") as mock_unlink:
+        mock_unlink.side_effect = Exception()
+        with pytest.raises(JujuSpellError):
+            print(file_cache.cache_directory)
+            file_cache.delete(key)
+
+
+def test_unknown_backend():
+    with pytest.raises(JujuSpellError, match=f"Supported cache backends are {AVALIABLE_BACKENDS}"):
+        use_cache("unknown_backend")


### PR DESCRIPTION
This PR extends and generailized the existing caching mechanism and defines a cache policy that can be used by any cache object.

- When run as `juju-spell list-models`
   - **[new]** If cached result exist but the cache is expired (based on the cache policy), it will fetch result from the controller and then save the result to the cache directory.
- Define abstract generic interface `get` and `put`
- Implement concrete `FileCache` with `get`, `put`, and `delete`

Example cache layout:

```bash
/home/raychan/.local/share/juju-spell/caches/
├── ListModelsCommand_030ccab2-b4a8-477b-854e-5715a74b320a
└── ListModelsCommand_bf74ae2d-5934-4adf-86c9-3393882682c8
```

Example cache file content:

```bash
# ~/.local/share/juju-spell/caches/ListModelsCommand_030ccab2-b4a8-477b-854e-5715a74b320a
data:
  models:
  - controller
  - cos-lite
  - jba
  - raychan96
timestamp: 1678870440.5674603
```

Reopen #99 